### PR TITLE
Add Projects section

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -6,6 +6,10 @@
   url: /publications/
   icon: fa-graduation-cap
 
+- title: Projects
+  url: /projects/
+  icon: fa-code-branch
+
 - title: CV
   url: /cv/
   icon: fa-file-alt

--- a/docs/_data/projects.yml
+++ b/docs/_data/projects.yml
@@ -1,0 +1,109 @@
+# Source of truth for the website's projects page.
+# Curated list of GitHub repositories Alessandro meaningfully contributed to —
+# mostly coursework from PoliMi and KTH, two ACM RecSys Challenge entries,
+# and one hackathon. Forks and throwaway sandboxes are intentionally excluded.
+# Sorted reverse-chronologically; the projects page sorts by `year` anyway.
+
+- title: "RecSys Challenge 2022 — 11th place"
+  repo: "https://github.com/Alexdruso/recsys2022"
+  year: 2022
+  role: "Team (3)"
+  context: "ACM RecSys Challenge 2022 @ Politecnico di Milano"
+  description: "11th-place solution to the ACM RecSys Challenge 2022. Three-stage pipeline: collaborative / content / graph recommenders, neural sequence models (Transformer, BiLSTM, GRU), and a 10-fold LGBM ranker on top — reached ~0.1965 MRR@100 on test."
+  tags: ["Python", "TensorFlow", "LightGBM", "Recommender Systems"]
+
+- title: "DD2437 — Artificial Neural Networks and Deep Architectures"
+  repo: "https://github.com/Alexdruso/DD2437-ANNDA-Colasanti-Sanvito-Stuart"
+  year: 2022
+  role: "Team (3)"
+  context: "DD2437 @ KTH Royal Institute of Technology"
+  description: "Four lab assignments implementing classical and deep neural architectures from scratch: perceptron / MLP, RBF networks and SOMs, Hopfield networks, and Restricted Boltzmann Machines / Deep Belief Networks."
+  tags: ["Python", "NumPy", "Jupyter", "Neural Networks"]
+
+- title: "II2202 — Quantum Ridge Regression on D-Wave"
+  repo: "https://github.com/Alexdruso/II2202-Research-Quantum-ML-Sanvito-Stuart"
+  year: 2022
+  role: "Team (2)"
+  context: "II2202 Research Methodology @ KTH Royal Institute of Technology"
+  description: "Empirical study of training Ridge regression on a D-Wave hybrid quantum annealer vs. classical Cholesky decomposition. Found that quantum-trained models do not match classical reliability across the datasets tested."
+  tags: ["Python", "D-Wave", "Quantum ML"]
+
+- title: "HackaTUMeme — gamified movie recommender"
+  repo: "https://github.com/Alexdruso/HackaTUMeme"
+  year: 2022
+  role: "Hackathon team"
+  context: "HackaTUM @ TU München"
+  description: "Conversational movie recommender that explores MovieLens as a graph rather than as a static carousel: temporarily expands the user profile during a session and surfaces films through trivia and social context."
+  tags: ["Python", "Django", "Lenskit", "TypeScript"]
+
+- title: "ID2222 — Data Mining lab assignments"
+  repo: "https://github.com/Alexdruso/ID2222-Data-Mining-Sanvito-Stuart"
+  year: 2023
+  role: "Team (2)"
+  context: "ID2222 Data Mining @ KTH Royal Institute of Technology"
+  description: "Five labs covering core data-mining algorithms: shingling + min-hash + LSH for near-duplicate detection, A-Priori association rules, the Triest streaming triangle counter, spectral clustering, and the JaBeJa graph partitioner."
+  tags: ["Java", "Jupyter", "Algorithms"]
+
+- title: "RecSys Challenge 2021 — Trial&Error team"
+  repo: "https://github.com/Alexdruso/recsys-challenge-2021-twitter-1"
+  year: 2021
+  role: "Team (8)"
+  context: "ACM RecSys Challenge 2021 @ Politecnico di Milano"
+  description: "Tweet-engagement prediction pipeline for the ACM RecSys Challenge 2021. LightGBM / XGBoost / CatBoost gradient boosting on transformer-derived features, distributed with Dask on AWS GPU/CPU instances."
+  tags: ["Python", "LightGBM", "XGBoost", "Transformers", "AWS"]
+
+- title: "Quantum linear regression on Orquestra"
+  repo: "https://github.com/Alexdruso/linear-regression-orquestra"
+  year: 2021
+  role: "Solo"
+  context: "Independent project"
+  description: "Orquestra component that trains an OLS linear regression model via simulated / quantum annealing — a stepping stone toward the later D-Wave Ridge regression study."
+  tags: ["Python", "Orquestra", "Quantum ML"]
+
+- title: "DB2 — JEE database application"
+  repo: "https://github.com/Alexdruso/db2-project"
+  year: 2021
+  role: "Solo"
+  context: "Databases 2 @ Politecnico di Milano"
+  description: "Enterprise-Java web application built on JPA, JEE, and Thymeleaf — full DDL schema, persistence layer, and templated UI for a Databases 2 course assignment."
+  tags: ["Java", "JEE", "JPA", "Thymeleaf"]
+
+- title: "CLup — RASD & Design Document"
+  repo: "https://github.com/Alexdruso/RivaSanvitoVecchio"
+  year: 2021
+  role: "Team (3)"
+  context: "Software Engineering 2 @ Politecnico di Milano"
+  description: "Requirements & Specification (RASD v1.2) and Design Document (DD v1.0) for the CLup queue-management application. Models written in Alloy and MagicDraw, mockups in Moqups."
+  tags: ["LaTeX", "Alloy", "Requirements Engineering"]
+
+- title: "Santorini — distributed multiplayer board game"
+  repo: "https://github.com/Alexdruso/ing-sw-2020-Riva-Sanvito-Truong"
+  year: 2020
+  role: "Team (3)"
+  context: "Software Engineering @ Politecnico di Milano"
+  description: "Full implementation of the Santorini board game in Java SE 14: socket networking, multiple concurrent matches, CLI + GUI clients, five advanced god powers, and a CircleCI pipeline with ~95% server-side test coverage."
+  tags: ["Java", "Maven", "Sockets", "CircleCI"]
+
+- title: "RecSys Challenge 2020 — PoliMi"
+  repo: "https://github.com/Alexdruso/recsys-challenge-2020-polimi"
+  year: 2020
+  role: "Solo"
+  context: "Recommender Systems course challenge @ Politecnico di Milano"
+  description: "5th / 8th (public / private) out of 66 in the in-class Kaggle challenge. Generalised N-score hybrid over MF-IALS, RP3-Beta and SLIM-ElasticNet, with a GPU-accelerated MF that cut training from ~10 min to 30 s."
+  tags: ["Python", "Cython", "Recommender Systems", "GPU"]
+
+- title: "Working-zones address decoder (VHDL)"
+  repo: "https://github.com/Alexdruso/Progetto-di-reti-logiche-2019"
+  year: 2020
+  role: "Team (2)"
+  context: "Reti Logiche @ Politecnico di Milano"
+  description: "VHDL hardware module that decodes 8-bit memory addresses using the working-zones locality scheme to reduce switching activity. Verified with Vivado testbenches; graded 30/30 cum laude."
+  tags: ["VHDL", "Vivado", "Digital Design"]
+
+- title: "API — graph-relationship engine in C"
+  repo: "https://github.com/Alexdruso/API-project"
+  year: 2019
+  role: "Solo"
+  context: "Algoritmi e Principi dell'Informatica @ Politecnico di Milano"
+  description: "Graph-mutation program (addent / addrel / delent / delrel / report) written in C and tuned for an automated grader on both runtime and memory budgets. Final score 30/30 cum laude."
+  tags: ["C", "Algorithms", "Performance"]

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,41 @@
+---
+title: Projects | Alessandro Sanvito
+layout: page
+permalink: /projects/
+---
+
+<div class="projects">
+  <p class="projects-header">
+    Selected GitHub projects — coursework from Politecnico di Milano and KTH, two ACM RecSys Challenge entries, and a hackathon.
+    Full list on
+    <a href="https://github.com/Alexdruso" target="_blank" rel="noopener">GitHub</a>.
+  </p>
+
+  {% assign projects = site.data.projects | sort: "year" | reverse %}
+  {% for project in projects %}
+    <article class="project-card">
+      <div class="project-meta">
+        <span class="project-year">{{ project.year }}</span>
+        {% if project.role %}<span class="role-chip">{{ project.role }}</span>{% endif %}
+      </div>
+
+      <h2 class="project-title">
+        <a href="{{ project.repo }}" target="_blank" rel="noopener">{{ project.title }}</a>
+      </h2>
+
+      {% if project.context %}<p class="project-context">{{ project.context }}</p>{% endif %}
+
+      <p class="project-description">{{ project.description }}</p>
+
+      {% if project.tags %}
+        <p class="project-tags">
+          {% for tag in project.tags %}<span class="tag-chip">{{ tag }}</span>{% endfor %}
+        </p>
+      {% endif %}
+
+      <p class="project-links">
+        <a href="{{ project.repo }}" target="_blank" rel="noopener"><i class="fab fa-github"></i> View on GitHub</a>
+      </p>
+    </article>
+  {% endfor %}
+</div>

--- a/docs/style.scss
+++ b/docs/style.scss
@@ -1122,3 +1122,172 @@ footer {
     font-size: 0.8em;
   }
 }
+
+// Projects
+.projects {
+  margin-bottom: 3rem;
+}
+
+.projects-header {
+  color: $gray;
+  font-size: 0.95em;
+  margin: 0 0 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid $lightGray;
+}
+
+.project-card {
+  padding: 1.25rem 0 1.5rem;
+  border-bottom: 1px solid $lightGray;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.project-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.85em;
+}
+
+.project-year {
+  color: $gray;
+  font-weight: 500;
+}
+
+.role-chip {
+  background-color: $lightBlue;
+  color: $accentBlue;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 0.8em;
+}
+
+.project-title {
+  font-size: 1.2em;
+  margin: 0.2rem 0 0.4rem;
+  line-height: 1.35;
+
+  a {
+    color: $darkerGray;
+    text-decoration: none;
+    border-bottom: none;
+
+    &:hover {
+      color: $blue;
+    }
+  }
+}
+
+.project-context {
+  color: $gray;
+  font-style: italic;
+  font-size: 0.95em;
+  margin: 0 0 0.5rem;
+}
+
+.project-description {
+  margin: 0 0 0.5rem;
+  color: $darkGray;
+}
+
+.project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0 0 0.6rem;
+}
+
+.tag-chip {
+  display: inline-block;
+  background-color: $lightGray;
+  color: $darkGray;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75em;
+  font-weight: 500;
+}
+
+.project-links {
+  margin: 0;
+  font-size: 0.9em;
+
+  a {
+    color: $blue;
+    text-decoration: none;
+    margin-right: 1rem;
+
+    i {
+      margin-right: 0.25rem;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+// Dark theme adjustments for projects
+.dark-theme {
+  .projects-header {
+    color: $dark-gray;
+    border-bottom-color: $dark-border;
+  }
+
+  .project-card {
+    border-bottom-color: $dark-border;
+  }
+
+  .project-title a {
+    color: $dark-text;
+
+    &:hover {
+      color: $dark-accent-hover;
+    }
+  }
+
+  .project-context {
+    color: $dark-gray;
+  }
+
+  .project-description {
+    color: $dark-text;
+  }
+
+  .project-year {
+    color: $dark-gray;
+  }
+
+  .role-chip {
+    background-color: $dark-border;
+    color: $dark-accent-hover;
+  }
+
+  .tag-chip {
+    background-color: $dark-border;
+    color: $dark-text;
+  }
+
+  .project-links a {
+    color: $dark-accent;
+
+    &:hover {
+      color: $dark-accent-hover;
+    }
+  }
+}
+
+@include mobile {
+  .project-title {
+    font-size: 1.1em;
+  }
+
+  .project-meta {
+    font-size: 0.8em;
+  }
+}


### PR DESCRIPTION
Mirrors the Publications section: a YAML data file feeds a Liquid
loop in projects.md, rendered with custom SCSS cards (light + dark
theme). Seeded with 13 curated GitHub repositories — coursework from
PoliMi and KTH, two ACM RecSys Challenge entries, and the HackaTUM
hackathon. Navigation adds Projects between Publications and CV.

https://claude.ai/code/session_01NUSWxY9PcC8Me7jqJPk7Cx