### PR TITLE
Sync CV and homepage with current LinkedIn

### DIFF
--- a/docs/cv-src/awesome-cv.cls
+++ b/docs/cv-src/awesome-cv.cls
@@ -189,6 +189,7 @@
 \newcommand*{\entrypositionstyle}[1]{{\fontsize{8pt}{1em}\bodyfont\scshape\color{graytext} #1}}
 \newcommand*{\entrydatestyle}[1]{{\fontsize{8pt}{1em}\bodyfontlight\slshape\color{graytext} #1}}
 \newcommand*{\entrylocationstyle}[1]{{\fontsize{9pt}{1em}\bodyfontlight\slshape\color{awesome} #1}}
+\newcommand*{\entrygradestyle}[1]{{\fontsize{8pt}{1em}\bodyfont\itshape\color{awesome} #1}}
 \newcommand*{\descriptionstyle}[1]{{\fontsize{9pt}{1em}\bodyfontlight\upshape\color{text} #1}}
 
 % For elements of subentry
@@ -591,6 +592,21 @@
       {\entrytitlestyle{#2} & \entrylocationstyle{#3} \\
       \entrypositionstyle{#1} & \entrydatestyle{#4} \\}
     \multicolumn{2}{L{\textwidth}}{\descriptionstyle{#5}}
+  \end{tabular*}%
+  \vspace{-1.0mm}
+}
+
+% Define an entry of education with a grade row.
+% Usage: \cveducationentry{<degree>}{<institution>}{<location>}{<date>}{<grade>}{<description>}
+\newcommand*{\cveducationentry}[6]{%
+  \vspace{0.2mm}
+  \setlength\tabcolsep{0pt}
+  \setlength{\extrarowheight}{0pt}
+  \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} L{\textwidth - 4.5cm} R{4.5cm}}
+    \entrytitlestyle{#2} & \entrylocationstyle{#3} \\
+    \entrypositionstyle{#1} & \entrydatestyle{#4} \\
+     & \entrygradestyle{#5} \\
+    \multicolumn{2}{L{\textwidth}}{\descriptionstyle{#6}}
   \end{tabular*}%
   \vspace{-1.0mm}
 }

--- a/docs/cv-src/cv/education.tex
+++ b/docs/cv-src/cv/education.tex
@@ -11,11 +11,12 @@
   
 %---------------------------------------------------------
   
-  \cventry
+  \cveducationentry
     {MSc. in ICT Innovation, Data Science }
     {KTH Royal Institute of Technology}
     {Stockholm, Sweden}
-    {Sept. 2020 - May 2023 ~\textbar~ Grade: A}
+    {Sept. 2020 - May 2023}
+    {Grade: A}
     {
     \begin{cvitems} % Description(s) bullet points
         \item {Implemented from scratch a diverse range of neural network architectures in NumPy,\\ including MLPs, Hopfield Networks, and Deep Belief Networks.}
@@ -39,11 +40,12 @@
   
 %---------------------------------------------------------
   
-  \cventry
+  \cveducationentry
     {MSc. in Computer Science and Engineering }
     {Polytechnic University of Milan}
     {Milan, Italy}
-    {Sept. 2020 - Jul. 2023 ~\textbar~ Grade: 110/110 cum laude}
+    {Sept. 2020 - Jul. 2023}
+    {Grade: 110/110 cum laude}
     {
     \begin{cvitems} % Description(s) bullet points
         \item {Developed a winning ML solution on the Twitter dataset for the international RecSys Challenge 2021\\with the university team under the supervision of prof. Paolo Cremonesi with Dask, Catboost, and XGBoost.}
@@ -55,11 +57,12 @@
   
 %---------------------------------------------------------
   
-  \cventry
+  \cveducationentry
     {BSc. in Engineering of Computing Systems } % Degree
     {Polytechnic University of Milan} % Institution
     {Milan, Italy} % Location
-    {Sept. 2017 - Jul. 2020 ~\textbar~ Grade: 109/110} % Date(s)
+    {Sept. 2017 - Jul. 2020} % Date(s)
+    {Grade: 109/110} % Grade
     {
       \begin{cvitems} % Description(s) bullet points
         \item {Implemented a cardboard game in Java, performing extensive testing with JUnit and Mockito.}

--- a/docs/cv-src/cv/education.tex
+++ b/docs/cv-src/cv/education.tex
@@ -15,10 +15,9 @@
     {MSc. in ICT Innovation, Data Science }
     {KTH Royal Institute of Technology}
     {Stockholm, Sweden}
-    {Sept. 2020 - May 2023}
+    {Sept. 2020 - May 2023 ~\textbar~ Grade: A}
     {
     \begin{cvitems} % Description(s) bullet points
-        \item {Final grade: A - Excellent}
         \item {Implemented from scratch a diverse range of neural network architectures in NumPy,\\ including MLPs, Hopfield Networks, and Deep Belief Networks.}
         \item {Reproduced data mining-related papers in Python and Java.}
 %        \item {Developed multiple projects in the Apache Spark ecosystem.}
@@ -44,10 +43,9 @@
     {MSc. in Computer Science and Engineering }
     {Polytechnic University of Milan}
     {Milan, Italy}
-    {Sept. 2020 - Jul. 2023}
+    {Sept. 2020 - Jul. 2023 ~\textbar~ Grade: 110/110 cum laude}
     {
     \begin{cvitems} % Description(s) bullet points
-        \item {Final grade: 110/110 cum laude}
         \item {Developed a winning ML solution on the Twitter dataset for the international RecSys Challenge 2021\\with the university team under the supervision of prof. Paolo Cremonesi with Dask, Catboost, and XGBoost.}
         %\item {Developed a 5 years strategic plan for Haier Europe in the smart home sector.}
         \item {Built a recommender system for a book catalogue with NumPy, SciPy, and Pandas.}
@@ -61,10 +59,9 @@
     {BSc. in Engineering of Computing Systems } % Degree
     {Polytechnic University of Milan} % Institution
     {Milan, Italy} % Location
-    {Sept. 2017 - Jul. 2020} % Date(s)
+    {Sept. 2017 - Jul. 2020 ~\textbar~ Grade: 109/110} % Date(s)
     {
       \begin{cvitems} % Description(s) bullet points
-        \item {Final grade: 109/110}
         \item {Implemented a cardboard game in Java, performing extensive testing with JUnit and Mockito.}
         %\item {Described in VHDL a circuit to perform address decoding with the working zones method.}
         \item {Created a performance oriented graph manipulation tool in C.}

--- a/docs/cv-src/cv/experience.tex
+++ b/docs/cv-src/cv/experience.tex
@@ -15,9 +15,10 @@
     {August 2023 - Current} % Date(s)
     {
       \begin{cvitems} % Description(s) of tasks/responsibilities
-        \item {Working in the Data Driven Algorithmic Position Taking team, developing and maintaining data pipelines and trading strategies.}
-        \item {Building and optimizing data processing systems using Python, Spark, Polars, and DuckDB, with a focus on efficient data storage and retrieval from PostgreSQL and Delta tables.}
-        \item {Collaborating closely with quantitative researchers and traders to implement and optimize systematic trading strategies, with direct impact on desk PnL.}
+        \item {Building high-performance research infrastructure for systematic trading in the Quantitative Volatility Strategies team (previously Options Data Engineering).}
+        \item {Architected data pipelines with Spark, Polars, and DuckDB processing 10+ TB of instrument-level data, reducing core backtest execution time by 60\%.}
+        \item {Expanded the desk's reach into new product groups by building and seeding initial strategies, enabling Quantitative Researchers to rapidly optimise alpha.}
+        \item {Built scalable tooling that tightens the research-to-production feedback loop for high-frequency strategies, with direct impact on desk PnL.}
       \end{cvitems}
     }
 
@@ -25,14 +26,14 @@
   \cventry
     {AI Research Intern and Master Thesis Student} % Job title
     {Mercedes-Benz (AI-SEE Project)} % Organization
-    {Stuttgart, Germany} % Location
-    {May 2022 - June 2023} % Date(s)
+    {Böblingen, Germany} % Location
+    {May 2022 - July 2023} % Date(s)
     {
       \begin{cvitems} % Description(s) of tasks/responsibilities
-        \item {Conducted cutting-edge research on 3D human avatar modeling from monocular video data in diverse real-world environments.}
-        \item {Designed and implemented generative neural models, including NeRFs and Diffusion Models, to improve computer vision performance in adverse weather conditions.}
-        \item {Collaborated with a cross-functional R\&D team to refine innovative ideas, resulting in a publication at ICCV (International Conference on Computer Vision).}
-        \item {Leveraged skills in deep learning, 3D modeling, and generative AI to push the boundaries of digital character creation and visualization.}
+        \item {Advanced 3D computer vision and Neural Radiance Fields for autonomous driving in adverse weather conditions.}
+        \item {Co-authored ScatterNeRF (ICCV 2023) and HINT (IEEE IV 2024), tackling novel view synthesis and 3D human reconstruction from limited viewpoints.}
+        \item {Outperformed state-of-the-art baselines in PSNR and SSIM for reconstructing scenes in fog, haze, and limited-viewpoint conditions.}
+        \item {Designed and implemented generative neural models, including NeRFs and Diffusion Models, collaborating with a cross-functional R\&D team.}
       \end{cvitems}
     }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ layout: page
 
 <div class="about-container">
   <div class="about-content">
-    I'm <strong>Alessandro Sanvito</strong>, a Software Engineer at <strong>Optiver</strong> in Amsterdam, where I work in the Data Driven Algorithmic Position Taking team. I specialize in developing data pipelines and trading strategies for systematic trading, combining software engineering expertise with quantitative finance knowledge to create impactful solutions.
+    I'm <strong>Alessandro Sanvito</strong>, a Software Engineer at <strong>Optiver</strong> in Amsterdam, where I work in the Quantitative Volatility Strategies team. I build high-performance research infrastructure that sits at the intersection of quantitative research and engineering, turning large-scale market data into systematic trading strategies.
   </div>
 </div>
 
@@ -13,11 +13,11 @@ layout: page
 
 <div class="about-container">
   <div class="about-content">
-    My professional path has been driven by a passion for technology and innovation, leading me through various exciting roles in software engineering and artificial intelligence. Currently, I'm making my mark at Optiver in Amsterdam, where I'm part of the Data Driven Algorithmic Position Taking team. Here, I'm combining my expertise in software engineering with quantitative finance to develop sophisticated data pipelines and trading strategies that directly impact our trading operations.
+    My professional path has been driven by a passion for technology and innovation, leading me through various exciting roles in software engineering and artificial intelligence. Currently, I'm making my mark at Optiver in Amsterdam, where I'm part of the Quantitative Volatility Strategies team — having joined the firm in Options Data Engineering before moving into my current role. Here, I'm combining my expertise in software engineering with quantitative finance to build the research infrastructure that powers systematic trading.
 
-    My work at Optiver involves creating robust data processing systems using modern technologies like Python, Spark, Polars, and DuckDB. I focus on building efficient data storage solutions with PostgreSQL and Delta tables, while working closely with quantitative researchers and traders to implement and optimize systematic trading strategies. This role allows me to blend technical expertise with business impact, as our solutions directly contribute to the desk's performance.
+    My work at Optiver centres on architecting data pipelines with Python, Spark, Polars, and DuckDB that process 10+ TB of instrument-level data, where I've cut core backtest execution times by around 60%. I work closely with Quantitative Researchers and traders to seed strategies in new product groups and tighten the research-to-production feedback loop for high-frequency strategies. This role lets me blend deep technical work with business impact, as the tooling I build feeds directly into desk PnL.
 
-    Before joining Optiver, I had the incredible opportunity to work as an AI Research Intern at Mercedes-Benz, where I was part of the AI-SEE Project in Stuttgart. This experience was transformative, as I delved into cutting-edge research on 3D human avatar modeling from monocular video data. I designed and implemented innovative generative neural models, including NeRFs and Diffusion Models, pushing the boundaries of what's possible in computer vision. Our team's work was recognized with publications at the International Conference on Computer Vision (ICCV) and the IEEE Intelligent Vehicles Symposium (IV) — see the full list on my <a href="/publications/">publications page</a>.
+    Before joining Optiver, I had the incredible opportunity to work on the AI-SEE Project at Mercedes-Benz in Böblingen, first as a working student and then as a master thesis student. This experience was transformative, as I delved into cutting-edge research on 3D scene reconstruction and human avatar modelling from monocular video data, pushing Neural Radiance Fields and Diffusion Models to perform under fog, haze, and limited viewpoints. I co-authored ScatterNeRF at the International Conference on Computer Vision (ICCV) and HINT at the IEEE Intelligent Vehicles Symposium (IV) — see the full list on my <a href="/publications/">publications page</a>.
   </div>
   <div class="profile-picture">
     <img src="/images/alessandro.jpeg" alt="Alessandro Sanvito" />


### PR DESCRIPTION
- experience.tex: refresh Optiver bullets for Quantitative Volatility
  Strategies role (10+ TB pipelines, 60% backtest speedup, alpha
  generation in new product groups); update Mercedes-Benz bullets to
  cover both ScatterNeRF (ICCV) and HINT (IEEE IV); correct Mercedes
  location to Boeblingen
- education.tex: move grades from first bullet to right-aligned
  dates column using \textbar separator
- index.md: update homepage narrative to match new Optiver team and
  Mercedes location/publications

https://claude.ai/code/session_01T9phkQjuLAsJk2V6LiJh61