### PR TITLE
Add Blog tab to site navigation

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -10,6 +10,10 @@
   url: /projects/
   icon: fa-code-branch
 
+- title: Blog
+  url: /blog/
+  icon: fa-pen-nib
+
 - title: CV
   url: /cv/
   icon: fa-file-alt


### PR DESCRIPTION
## Summary

- Adds a "Blog" entry to the site navigation bar, linking to `/blog/`
- The `/blog/` page (`posts.html`) already exists and lists all posts — it just wasn't reachable from the nav

## Test plan

- [ ] After merge, confirm "Blog" tab appears in the header nav on all pages
- [ ] Clicking it lands on the blog listing at `https://alessandrosanvito.me/blog/`
- [ ] The MDP post appears in the listing with its excerpt and "Read More" link

https://claude.ai/code/session_0144kWPQHBW6hsXoe1Pqynee

---
_Generated by [Claude Code](https://claude.ai/code/session_0144kWPQHBW6hsXoe1Pqynee)_