### PR TITLE
Remove stale CNAME for expired custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-alessandrosanvito.me


### PR DESCRIPTION
The `alessandrosanvito.me` domain has expired, so the site is served from `alexdruso.github.io`. This removes the leftover `CNAME` file so GitHub Pages can't associate the repo with (or redirect visitors to) the dead domain.

https://claude.ai/code/session_01MQWLUEptQeouUFryiR2jxi

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQWLUEptQeouUFryiR2jxi)_