### PR TITLE
Rename Blog section to Study Notes; add interactive Shannon entropy note

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -10,9 +10,9 @@
   url: /projects/
   icon: fa-code-branch
 
-- title: Blog
-  url: /blog/
-  icon: fa-pen-nib
+- title: Study Notes
+  url: /study-notes/
+  icon: fa-book-open
 
 - title: CV
   url: /cv/

--- a/docs/_posts/2026-06-16-shannon-entropy-visually.html
+++ b/docs/_posts/2026-06-16-shannon-entropy-visually.html
@@ -1,0 +1,673 @@
+---
+layout: post
+title: "Shannon Entropy, Visually: Surprise, Uncertainty, and Bits"
+date: 2026-06-16
+categories: [Information Theory, Interactive]
+excerpt: "Entropy gets introduced as a formula — −Σ p log p — and the intuition evaporates on contact. This is the refresher I wish I'd had: entropy is just average surprise, measured in yes/no questions. Drag a coin's bias, reshape a distribution, and watch a sampler's running surprise converge onto the entropy, live in your browser."
+---
+
+<style>
+/* ===== layout ===== */
+.se-section {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+}
+.dark-theme .se-section { background: #1e1e2e; border-color: #313244; }
+.se-section h3 { margin-top: 0; color: #8e44ad; }
+.dark-theme .se-section h3 { color: #c8a2e8; }
+.se-section h4 { margin-bottom: 0.5rem; }
+
+.se-equation {
+  padding: 1rem 1.5rem;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid #dee2e6;
+  font-size: 1.1rem;
+  text-align: center;
+  margin: 1rem 0;
+  overflow-x: auto;
+}
+.dark-theme .se-equation { background: #14141e; border-color: #313244; }
+.se-equation .big { font-size: 1.25rem; }
+
+.se-note {
+  background: #f3e9fb;
+  border-radius: 8px;
+  padding: 0.9rem 1.1rem;
+  border-left: 4px solid #8e44ad;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}
+.dark-theme .se-note { background: #251a30; border-left-color: #c8a2e8; }
+
+.se-example {
+  background: #fff8e1;
+  border-radius: 8px;
+  padding: 1rem;
+  border: 1px solid #ffe082;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}
+.dark-theme .se-example { background: #2a2500; border-color: #554400; }
+
+/* ===== controls ===== */
+.se-controls { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
+.se-btn {
+  padding: 0.5rem 1.1rem;
+  border-radius: 8px;
+  border: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  background: #8e44ad;
+  color: white;
+  font-family: inherit;
+}
+.se-btn.sec { background: #5d6d7e; }
+.se-btn:hover:not(:disabled) { filter: brightness(0.9); }
+.se-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.se-reset {
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+.se-reset:hover { background: #eee; }
+.dark-theme .se-reset { border-color: #444; color: #ccc; }
+.dark-theme .se-reset:hover { background: #252535; }
+
+.se-slider { -webkit-appearance: none; appearance: none; height: 6px; border-radius: 3px;
+  background: linear-gradient(90deg,#3498db,#8e44ad,#e74c3c); outline: none; cursor: pointer; }
+.se-slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 18px; height: 18px;
+  border-radius: 50%; background: #fff; border: 2px solid #8e44ad; cursor: pointer; }
+.se-slider::-moz-range-thumb { width: 18px; height: 18px; border-radius: 50%; background: #fff;
+  border: 2px solid #8e44ad; cursor: pointer; }
+.se-readout { font-weight: 700; font-size: 1.05rem; min-width: 4.5rem; display: inline-block; }
+
+.se-flexwrap { display: flex; gap: 1.25rem; flex-wrap: wrap; align-items: flex-start; }
+.se-panel { flex: 1; min-width: 240px; }
+
+.se-stat { text-align: center; }
+.se-stat .lab { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; }
+.se-stat .val { font-size: 1.7rem; font-weight: 700; color: #8e44ad; line-height: 1.1; }
+.dark-theme .se-stat .val { color: #c8a2e8; }
+.se-statrow { display: flex; gap: 2rem; justify-content: center; margin: 0.5rem 0; }
+
+.se-tag {
+  display: inline-block; padding: 0.2rem 0.6rem; border-radius: 999px;
+  font-size: 0.8rem; font-weight: 600;
+}
+.se-tag.good { background: #d5f5e3; color: #1e8449; }
+.se-tag.warn { background: #fdebd0; color: #b9770e; }
+.se-tag.hot  { background: #fadbd8; color: #c0392b; }
+.dark-theme .se-tag.good { background: #14331f; color: #6fcf97; }
+.dark-theme .se-tag.warn { background: #3a2c10; color: #f0b24a; }
+.dark-theme .se-tag.hot  { background: #3a1714; color: #f1948a; }
+
+svg text { fill: #555; }
+.dark-theme svg text { fill: #bbb; }
+
+.se-chartwrap { background: #fff; border: 1px solid #e6e6ee; border-radius: 8px; padding: 0.4rem; }
+.dark-theme .se-chartwrap { background: #11111a; border-color: #2a2a3e; }
+
+.se-legend { font-size: 0.78rem; opacity: 0.75; display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 0.4rem; }
+.se-legend span::before { content: "■ "; }
+
+/* surprise meter */
+.se-meter { background: #e8e8ef; border-radius: 8px; height: 26px; overflow: hidden; position: relative; }
+.dark-theme .se-meter { background: #1d1d2c; }
+.se-meter > div { height: 100%; border-radius: 8px; transition: width 0.12s ease, background 0.12s ease; }
+
+/* distribution sliders */
+.se-distrow { display: grid; grid-template-columns: 90px 1fr 56px; gap: 0.6rem; align-items: center; margin: 0.45rem 0; }
+.se-distrow .nm { font-size: 0.9rem; }
+.se-distrow .pv { font-size: 0.85rem; text-align: right; opacity: 0.75; font-variant-numeric: tabular-nums; }
+
+@keyframes sepop { from { transform: scale(0.6); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+.se-pop { animation: sepop 0.25s ease; }
+</style>
+
+<p>
+  When I first met <strong>Shannon entropy</strong> at university it arrived the way it usually does —
+  as a formula, <em>H = −&Sigma; p log p</em>, scribbled on a board, followed by "and this measures
+  information." I copied it down, passed the exam, and lost every shred of intuition by the following
+  week. This post is the refresher I wish I'd had: built around one idea you can poke, drag, and run.
+</p>
+
+<p>Here's the whole story in one sentence, and everything below just unpacks it:</p>
+
+<div class="se-note">
+  <strong>Entropy is average surprise.</strong> A rare outcome is surprising and carries a lot of
+  information; a near-certain one carries almost none. Entropy is just the <em>expected</em> surprise
+  of a random draw — and because we measure surprise in <strong>bits</strong>, it literally counts the
+  average number of yes/no questions you'd need to pin down the outcome.
+</div>
+
+<!-- ============================================================ -->
+<!-- 1. SURPRISE / INFORMATION CONTENT                            -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>😲 The atom: surprise of a single outcome</h3>
+  <p style="margin-top:0">
+    Before averaging anything, look at one outcome. If an event has probability <em>p</em>, how
+    <em>surprised</em> should you be when it happens? Shannon's answer — the only one satisfying a few
+    natural rules — is the <strong>information content</strong>:
+  </p>
+  <div class="se-equation">
+    <span class="big">h(x) = log<sub>2</sub> ( 1 / p ) = −log<sub>2</sub> p</span> &nbsp; bits
+  </div>
+  <p style="margin-top:0">
+    Why this shape? A <strong>certain</strong> event (p = 1) tells you nothing new → 0 bits. Halve a
+    probability and you add exactly <strong>one bit</strong> of surprise (one extra yes/no question).
+    So p = ½ is 1 bit, p = ¼ is 2 bits, p = 1/8 is 3 bits. Drag the probability and watch the surprise:
+  </p>
+
+  <div class="se-flexwrap">
+    <div class="se-panel" style="flex:2">
+      <div class="se-chartwrap">
+        <svg id="se1-svg" width="100%" height="240" viewBox="0 0 460 240"></svg>
+      </div>
+    </div>
+    <div class="se-panel">
+      <div class="se-controls" style="margin-top:0">
+        <span style="font-size:0.85rem">p(x)</span>
+        <input type="range" id="se1-p" class="se-slider" min="1" max="1000" value="125" style="flex:1">
+        <span class="se-readout" id="se1-pval">0.125</span>
+      </div>
+      <div class="se-statrow">
+        <div class="se-stat"><div class="lab">surprise</div><div class="val" id="se1-bits">3.00</div><div class="lab" style="opacity:0.4">bits</div></div>
+      </div>
+      <div class="se-meter" style="margin:0.6rem 0"><div id="se1-meter" style="width:30%;background:#8e44ad"></div></div>
+      <div id="se1-msg" style="font-size:0.85rem;opacity:0.85;text-align:center;min-height:3.2em"></div>
+    </div>
+  </div>
+
+  <div class="se-flexwrap" style="margin-top:0.5rem">
+    <div class="se-example" style="flex:1;margin:0">
+      <strong>"The sun rose today" (p≈1):</strong> ≈ 0 bits. No information — you already knew it.
+    </div>
+    <div class="se-example" style="flex:1;margin:0">
+      <strong>"I flipped 7 heads in a row" (p = 1/128):</strong> 7 bits. Genuinely surprising, and it
+      takes 7 yes/no answers to single it out.
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 2. BIASED COIN / BERNOULLI ENTROPY                           -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🪙 Average surprise: the biased coin</h3>
+  <p style="margin-top:0">
+    Now average. A coin lands heads with probability <em>p</em>, tails with <em>1 − p</em>. Sometimes
+    you get the surprising outcome, sometimes the likely one. Weight each surprise by how often it
+    happens and you get the <strong>entropy</strong> of the coin:
+  </p>
+  <div class="se-equation">
+    <span class="big">H(p) = −p log<sub>2</sub> p − (1−p) log<sub>2</sub>(1−p)</span> &nbsp; bits
+  </div>
+  <p style="margin-top:0">
+    Drag the bias and watch the curve. It's <strong>maximal at p = ½</strong> — a fair coin is the most
+    uncertain, worth a full <strong>1 bit</strong> — and collapses to <strong>0</strong> at either end,
+    where the coin is rigged and there's nothing left to be surprised about.
+  </p>
+
+  <div class="se-flexwrap">
+    <div class="se-panel" style="flex:2">
+      <div class="se-chartwrap">
+        <svg id="se2-svg" width="100%" height="260" viewBox="0 0 460 260"></svg>
+      </div>
+    </div>
+    <div class="se-panel">
+      <div class="se-controls" style="margin-top:0">
+        <span style="font-size:0.85rem">p(heads)</span>
+        <input type="range" id="se2-p" class="se-slider" min="1" max="999" value="500" style="flex:1">
+        <span class="se-readout" id="se2-pval">0.50</span>
+      </div>
+      <div class="se-statrow">
+        <div class="se-stat"><div class="lab">entropy H</div><div class="val" id="se2-h">1.00</div><div class="lab" style="opacity:0.4">bits</div></div>
+      </div>
+      <div style="text-align:center;margin:0.4rem 0"><span id="se2-tag" class="se-tag warn">maximally uncertain</span></div>
+      <div id="se2-msg" style="font-size:0.85rem;opacity:0.85;text-align:center;min-height:3em"></div>
+    </div>
+  </div>
+
+  <div class="se-note" style="margin-bottom:0">
+    <strong>Notice the asymmetry of certainty:</strong> moving from p = 0.5 to 0.6 barely dents the
+    entropy, but moving from 0.9 to 0.99 sheds a lot. The last scraps of uncertainty are the cheapest
+    to remove — which is exactly why confident predictions are so informative.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 3. DISTRIBUTION EXPLORER                                     -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🎛️ More than two outcomes: shape a distribution</h3>
+  <p style="margin-top:0">
+    Coins are just the two-outcome case. For any distribution over outcomes <em>x</em>, entropy is the
+    same average-surprise idea, summed over everything that can happen:
+  </p>
+  <div class="se-equation">
+    <span class="big">H = &Sigma;<sub>x</sub> p(x) · log<sub>2</sub> ( 1 / p(x) ) = −&Sigma;<sub>x</sub> p(x) log<sub>2</sub> p(x)</span>
+  </div>
+  <p style="margin-top:0">
+    Below are tomorrow's weather odds. Drag the sliders to re-shape the distribution (the bars
+    renormalise to sum to 1) and watch the entropy meter. Two limits bracket everything:
+    <strong>0 bits</strong> when one outcome is certain, and <strong>log<sub>2</sub>N</strong> bits when
+    all <em>N</em> outcomes are equally likely — maximum ignorance.
+  </p>
+
+  <div class="se-flexwrap">
+    <div class="se-panel" style="flex:0 0 300px">
+      <div id="se3-sliders"></div>
+      <div class="se-controls" style="justify-content:center;margin-top:0.8rem">
+        <button class="se-btn" id="se3-uniform">⚖️ Make uniform</button>
+        <button class="se-reset" id="se3-certain">🎯 Make certain</button>
+      </div>
+    </div>
+    <div class="se-panel">
+      <div class="se-chartwrap">
+        <svg id="se3-svg" width="100%" height="220" viewBox="0 0 420 220"></svg>
+      </div>
+      <div class="se-statrow" style="margin-top:0.6rem">
+        <div class="se-stat"><div class="lab">entropy H</div><div class="val" id="se3-h">—</div><div class="lab" style="opacity:0.4">bits</div></div>
+        <div class="se-stat"><div class="lab">max (log<sub>2</sub>N)</div><div class="val" id="se3-max" style="color:#5d6d7e">—</div><div class="lab" style="opacity:0.4">bits</div></div>
+      </div>
+      <div style="text-align:center"><span id="se3-tag" class="se-tag warn">—</span></div>
+    </div>
+  </div>
+
+  <div class="se-flexwrap" style="margin-top:0.5rem">
+    <div class="se-example" style="flex:1;margin:0">
+      <strong>Make it certain</strong> (push one slider to the top): H → 0. If you already know it'll be
+      sunny, a forecast tells you nothing.
+    </div>
+    <div class="se-example" style="flex:1;margin:0">
+      <strong>Make it uniform:</strong> H peaks at log<sub>2</sub>N. With <em>N</em> equally likely
+      states, that's the most a forecast could ever tell you.
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 4. SAMPLER / LAW OF LARGE NUMBERS                            -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🎲 "Average surprise" is not a metaphor</h3>
+  <p style="margin-top:0">
+    Entropy is an <em>expectation</em>, so let's actually take the average. Using the distribution you
+    shaped above, we'll draw outcomes one at a time, score each draw by its surprise
+    −log<sub>2</sub>p(x), and track the <strong>running average</strong>. By the law of large numbers it
+    must home in on the entropy H — the dashed line — no matter where it starts.
+  </p>
+
+  <div class="se-controls">
+    <button class="se-btn" id="se4-run">▶ Run sampler</button>
+    <button class="se-btn sec" id="se4-step">Draw 25</button>
+    <button class="se-reset" id="se4-reset">↺ Reset</button>
+  </div>
+
+  <div class="se-chartwrap">
+    <svg id="se4-svg" width="100%" height="200" viewBox="0 0 720 200" preserveAspectRatio="none" style="display:block"></svg>
+  </div>
+  <div class="se-legend">
+    <span style="color:#8e44ad">running average surprise</span>
+    <span style="color:#27ae60">entropy H (target)</span>
+  </div>
+
+  <div class="se-statrow" style="margin-top:0.6rem">
+    <div class="se-stat"><div class="lab">draws</div><div class="val" id="se4-n">0</div></div>
+    <div class="se-stat"><div class="lab">avg surprise</div><div class="val" id="se4-avg">—</div></div>
+    <div class="se-stat"><div class="lab">entropy H</div><div class="val" id="se4-h" style="color:#27ae60">—</div></div>
+  </div>
+  <div class="se-note" style="margin-bottom:0">
+    <strong>Try this:</strong> shape a lopsided distribution above, then run the sampler — the average
+    surprise still converges onto H, just to a lower value. Then make it uniform and watch it climb to
+    log<sub>2</sub>N. The wiggling early on is small-sample noise; it always settles.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- WRAP UP                                                      -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🎯 The whole story in one breath</h3>
+  <ul style="line-height:1.7">
+    <li><strong>Surprise</strong> of one outcome is −log<sub>2</sub>p: rare = many bits, certain = zero.</li>
+    <li><strong>Entropy</strong> is the average surprise — the expected bits per draw, <em>H = −&Sigma; p log<sub>2</sub> p</em>.</li>
+    <li>It's <strong>maximised by uniformity</strong> (log<sub>2</sub>N bits — total ignorance) and <strong>zero under certainty</strong>.</li>
+    <li>Measured in <strong>bits</strong>, it's the average number of optimal yes/no questions — and the floor on lossless compression (Shannon's source coding theorem).</li>
+  </ul>
+  <p style="margin-bottom:0">
+    Same single idea everywhere: <strong>information is resolved uncertainty</strong>. Entropy just
+    counts, in bits, how much there was to resolve. Once you see −log p as "surprise," the formula stops
+    being a magic incantation and starts being obvious.
+  </p>
+</div>
+
+<script>
+(function () {
+  "use strict";
+  const log2 = x => Math.log(x) / Math.LN2;
+  const clamp = (x, a, b) => Math.max(a, Math.min(b, x));
+  // surprise of an event, guarded against p<=0
+  const surprise = p => (p > 0 ? -log2(p) : 0);
+  // entropy of a distribution (array of probabilities)
+  const entropy = ps => ps.reduce((h, p) => h + (p > 0 ? -p * log2(p) : 0), 0);
+
+  // ============================================================
+  // DEMO 1 — surprise / information content  h = -log2 p
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("se1-svg");
+    const pSlider = document.getElementById("se1-p");
+    const pval = document.getElementById("se1-pval");
+    const bitsEl = document.getElementById("se1-bits");
+    const meter = document.getElementById("se1-meter");
+    const msg = document.getElementById("se1-msg");
+
+    const W = 460, H = 240, padL = 44, padR = 16, padT = 16, padB = 38;
+    const pMin = 0.001, pMax = 1;
+    const X = p => padL + (p - pMin) / (pMax - pMin) * (W - padL - padR);
+    const hMax = surprise(0.03);                 // ~5 bits, top of plotted range
+    const Y = h => H - padB - clamp(h, 0, hMax) / hMax * (H - padT - padB);
+
+    const pOf = () => clamp(pSlider.value / 1000, pMin, 1);
+
+    function draw() {
+      const p = pOf();
+      const h = surprise(p);
+      pval.textContent = p.toFixed(3);
+      bitsEl.textContent = h.toFixed(2);
+      meter.style.width = clamp(h / hMax * 100, 2, 100).toFixed(1) + "%";
+      meter.style.background = h < 1 ? "#27ae60" : h < 3 ? "#8e44ad" : "#e74c3c";
+
+      // curve h = -log2 p
+      let path = "";
+      for (let k = 0; k <= 220; k++) {
+        const pp = pMin + (pMax - pMin) * k / 220;
+        path += (k === 0 ? "M" : "L") + X(pp).toFixed(1) + " " + Y(surprise(pp)).toFixed(1) + " ";
+      }
+      // gridlines: bits
+      let grid = "";
+      [0, 1, 2, 3, 4, 5].forEach(b => {
+        if (b > hMax) return;
+        grid += `<line x1="${padL}" y1="${Y(b)}" x2="${W - padR}" y2="${Y(b)}" stroke="#eee" stroke-width="1"/>`;
+        grid += `<text x="${padL - 6}" y="${Y(b) + 3}" font-size="10" text-anchor="end">${b}</text>`;
+      });
+      [0, 0.25, 0.5, 0.75, 1].forEach(px => {
+        grid += `<line x1="${X(px)}" y1="${padT}" x2="${X(px)}" y2="${H - padB}" stroke="#f1f1f1" stroke-width="1"/>`;
+        grid += `<text x="${X(px)}" y="${H - padB + 16}" font-size="10" text-anchor="middle">${px}</text>`;
+      });
+      const marker =
+        `<line x1="${X(p)}" y1="${Y(h)}" x2="${X(p)}" y2="${H - padB}" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="3 3"/>` +
+        `<circle cx="${X(p)}" cy="${Y(h)}" r="6" fill="#e74c3c"/>` +
+        `<text x="${clamp(X(p) + 9, padL, W - padR - 60)}" y="${clamp(Y(h) - 6, padT + 12, H - padB)}" font-size="12" fill="#e74c3c" font-weight="700">${h.toFixed(2)} bits</text>`;
+      svg.innerHTML =
+        grid +
+        `<path d="${path}" fill="none" stroke="#8e44ad" stroke-width="2.5"/>` +
+        marker +
+        `<text x="${X(0.5)}" y="${H - 4}" font-size="11" text-anchor="middle">probability of the outcome  p(x)</text>` +
+        `<text x="13" y="${padT + 84}" font-size="11" transform="rotate(-90 13 ${padT + 84})" text-anchor="middle">surprise (bits)</text>`;
+
+      if (p > 0.9) msg.innerHTML = "Almost certain — barely any surprise. A forecast like this tells you next to nothing.";
+      else if (p > 0.45 && p < 0.55) msg.innerHTML = "A coin-flip outcome: <strong>exactly 1 bit</strong> of surprise.";
+      else if (p < 0.05) msg.innerHTML = "Rare and shocking — many bits. It'd take this many yes/no questions to single it out.";
+      else msg.innerHTML = "Halve the probability and the surprise goes up by exactly one bit.";
+    }
+    pSlider.addEventListener("input", draw);
+    draw();
+  })();
+
+  // ============================================================
+  // DEMO 2 — Bernoulli entropy  H(p)
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("se2-svg");
+    const pSlider = document.getElementById("se2-p");
+    const pval = document.getElementById("se2-pval");
+    const hEl = document.getElementById("se2-h");
+    const tag = document.getElementById("se2-tag");
+    const msg = document.getElementById("se2-msg");
+
+    const W = 460, H = 260, padL = 44, padR = 16, padT = 16, padB = 38;
+    const X = p => padL + p * (W - padL - padR);
+    const Y = h => H - padB - h * (H - padT - padB);     // H ranges 0..1
+    const Hbern = p => entropy([p, 1 - p]);
+
+    const pOf = () => clamp(pSlider.value / 1000, 0.001, 0.999);
+
+    function draw() {
+      const p = pOf();
+      const h = Hbern(p);
+      pval.textContent = p.toFixed(2);
+      hEl.textContent = h.toFixed(2);
+
+      let path = "";
+      for (let k = 0; k <= 200; k++) {
+        const pp = clamp(k / 200, 0.0005, 0.9995);
+        path += (k === 0 ? "M" : "L") + X(pp).toFixed(1) + " " + Y(Hbern(pp)).toFixed(1) + " ";
+      }
+      let grid = "";
+      [0, 0.25, 0.5, 0.75, 1].forEach(b => {
+        grid += `<line x1="${padL}" y1="${Y(b)}" x2="${W - padR}" y2="${Y(b)}" stroke="#eee" stroke-width="1"/>`;
+        grid += `<text x="${padL - 6}" y="${Y(b) + 3}" font-size="10" text-anchor="end">${b.toFixed(2)}</text>`;
+      });
+      [0, 0.25, 0.5, 0.75, 1].forEach(px => {
+        grid += `<line x1="${X(px)}" y1="${padT}" x2="${X(px)}" y2="${H - padB}" stroke="#f1f1f1" stroke-width="1"/>`;
+        grid += `<text x="${X(px)}" y="${H - padB + 16}" font-size="10" text-anchor="middle">${px}</text>`;
+      });
+      const peak = `<line x1="${X(0.5)}" y1="${Y(1)}" x2="${X(0.5)}" y2="${H - padB}" stroke="#bbb" stroke-dasharray="4 4"/>` +
+        `<text x="${X(0.5)}" y="${Y(1) - 4}" font-size="10" text-anchor="middle" opacity="0.7">1 bit max</text>`;
+      const marker =
+        `<line x1="${X(p)}" y1="${Y(h)}" x2="${X(p)}" y2="${H - padB}" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="3 3"/>` +
+        `<circle cx="${X(p)}" cy="${Y(h)}" r="6" fill="#e74c3c"/>`;
+      svg.innerHTML =
+        grid + peak +
+        `<path d="${path}" fill="none" stroke="#8e44ad" stroke-width="2.5"/>` +
+        marker +
+        `<text x="${X(0.5)}" y="${H - 4}" font-size="11" text-anchor="middle">p(heads)</text>` +
+        `<text x="13" y="${padT + 92}" font-size="11" transform="rotate(-90 13 ${padT + 92})" text-anchor="middle">entropy H (bits)</text>`;
+
+      if (h > 0.95) { tag.textContent = "maximally uncertain"; tag.className = "se-tag warn"; }
+      else if (h < 0.2) { tag.textContent = "nearly rigged"; tag.className = "se-tag good"; }
+      else { tag.textContent = "biased coin"; tag.className = "se-tag hot"; }
+
+      if (p > 0.45 && p < 0.55) msg.innerHTML = "Fair coin — the most uncertain it can be, worth a full <strong>1 bit</strong>.";
+      else if (h < 0.1) msg.innerHTML = "The coin is almost rigged. You can predict it, so there's almost nothing left to learn.";
+      else msg.innerHTML = "Bias the coin and entropy falls: outcomes are easier to guess, so each carries fewer bits on average.";
+    }
+    pSlider.addEventListener("input", draw);
+    draw();
+  })();
+
+  // ============================================================
+  // SHARED distribution state for demos 3 & 4
+  // ============================================================
+  const dist = {
+    names: ["☀️ Sunny", "⛅ Cloudy", "🌧️ Rain", "⛈️ Storm", "❄️ Snow"],
+    colors: ["#f39c12", "#7f8c8d", "#2980b9", "#8e44ad", "#16a3c9"],
+    raw: [5, 3, 2, 1, 0.6],   // unnormalised slider weights
+    probs() { const s = this.raw.reduce((a, b) => a + b, 0); return this.raw.map(w => w / s); },
+    listeners: [],
+    notify() { this.listeners.forEach(fn => fn()); }
+  };
+
+  // ============================================================
+  // DEMO 3 — distribution explorer
+  // ============================================================
+  (function () {
+    const N = dist.names.length;
+    const slidersEl = document.getElementById("se3-sliders");
+    const svg = document.getElementById("se3-svg");
+    const hEl = document.getElementById("se3-h");
+    const maxEl = document.getElementById("se3-max");
+    const tag = document.getElementById("se3-tag");
+    const maxH = log2(N);
+
+    // build sliders
+    const inputs = [];
+    for (let i = 0; i < N; i++) {
+      const row = document.createElement("div");
+      row.className = "se-distrow";
+      const nm = document.createElement("span"); nm.className = "nm"; nm.textContent = dist.names[i];
+      const inp = document.createElement("input");
+      inp.type = "range"; inp.className = "se-slider"; inp.min = "0"; inp.max = "100";
+      inp.value = Math.round(dist.raw[i] / 5 * 100);
+      inp.style.flex = "1";
+      const pv = document.createElement("span"); pv.className = "pv";
+      row.appendChild(nm); row.appendChild(inp); row.appendChild(pv);
+      slidersEl.appendChild(row);
+      inputs.push({ inp, pv });
+      inp.addEventListener("input", () => {
+        dist.raw[i] = Math.max(0.0001, inp.value / 100 * 5);
+        dist.notify();
+      });
+    }
+
+    const W = 420, H = 220, padT = 14, padB = 30, padL = 8;
+    function draw() {
+      const probs = dist.probs();
+      const h = entropy(probs);
+      hEl.textContent = h.toFixed(2);
+      maxEl.textContent = maxH.toFixed(2);
+      // sync slider readouts + reflect external changes (uniform/certain buttons)
+      for (let i = 0; i < N; i++) {
+        inputs[i].pv.textContent = (probs[i] * 100).toFixed(0) + "%";
+        const v = Math.round(dist.raw[i] / 5 * 100);
+        if (+inputs[i].inp.value !== v) inputs[i].inp.value = v;
+      }
+      // bars
+      const slot = (W - padL) / N, barW = slot * 0.64, top = H - padT - padB;
+      let out = "";
+      [0.25, 0.5, 0.75, 1].forEach(f => {
+        const y = H - padB - f * top;
+        out += `<line x1="${padL}" y1="${y}" x2="${W}" y2="${y}" stroke="#eee" stroke-width="1"/>`;
+      });
+      probs.forEach((p, i) => {
+        const x = padL + i * slot + (slot - barW) / 2;
+        const bh = p * top, yTop = H - padB - bh;
+        out += `<rect x="${x.toFixed(1)}" y="${yTop.toFixed(1)}" width="${barW.toFixed(1)}" height="${bh.toFixed(1)}" rx="4" fill="${dist.colors[i]}"/>`;
+        out += `<text x="${(x + barW / 2).toFixed(1)}" y="${(yTop - 5).toFixed(1)}" font-size="10" text-anchor="middle">${(p * 100).toFixed(0)}%</text>`;
+        out += `<text x="${(x + barW / 2).toFixed(1)}" y="${H - padB + 16}" font-size="13" text-anchor="middle">${dist.names[i].split(" ")[0]}</text>`;
+      });
+      svg.innerHTML = out;
+
+      if (h > maxH - 0.03) { tag.textContent = "uniform → max entropy"; tag.className = "se-tag warn"; }
+      else if (h < 0.15) { tag.textContent = "near-certain → ~0 bits"; tag.className = "se-tag good"; }
+      else { tag.textContent = (h / maxH * 100).toFixed(0) + "% of maximum"; tag.className = "se-tag hot"; }
+    }
+
+    document.getElementById("se3-uniform").addEventListener("click", () => {
+      for (let i = 0; i < N; i++) dist.raw[i] = 1;
+      dist.notify();
+    });
+    document.getElementById("se3-certain").addEventListener("click", () => {
+      for (let i = 0; i < N; i++) dist.raw[i] = 0.0001;
+      dist.raw[0] = 5;
+      dist.notify();
+    });
+
+    dist.listeners.push(draw);
+    draw();
+  })();
+
+  // ============================================================
+  // DEMO 4 — sampler: running average surprise -> entropy
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("se4-svg");
+    const nEl = document.getElementById("se4-n");
+    const avgEl = document.getElementById("se4-avg");
+    const hEl = document.getElementById("se4-h");
+    const runBtn = document.getElementById("se4-run");
+
+    let n = 0, sumSurprise = 0;
+    const hist = [];          // running-average surprise after each draw
+    let running = false, raf = null;
+
+    // cumulative distribution for sampling current dist
+    function sampleIndex(probs) {
+      let r = Math.random(), acc = 0;
+      for (let i = 0; i < probs.length; i++) { acc += probs[i]; if (r <= acc) return i; }
+      return probs.length - 1;
+    }
+
+    function reset() {
+      n = 0; sumSurprise = 0; hist.length = 0;
+      stop();
+      draw();
+    }
+    function drawOne() {
+      const probs = dist.probs();
+      const i = sampleIndex(probs);
+      sumSurprise += surprise(probs[i]);
+      n++;
+      hist.push(sumSurprise / n);
+      if (hist.length > 2000) hist.shift();
+    }
+
+    const W = 720, H = 200, padL = 38, padR = 12, padT = 12, padB = 26;
+    function yScaleMax() { return Math.max(log2(dist.names.length), 0.5) * 1.08; }
+    function draw() {
+      const probs = dist.probs();
+      const Htarget = entropy(probs);
+      const yMax = yScaleMax();
+      const X = k => padL + (hist.length > 1 ? k / (hist.length - 1) : 0) * (W - padL - padR);
+      const Y = v => H - padB - clamp(v, 0, yMax) / yMax * (H - padT - padB);
+
+      nEl.textContent = n;
+      avgEl.textContent = n > 0 ? hist[hist.length - 1].toFixed(3) : "—";
+      hEl.textContent = Htarget.toFixed(3);
+
+      // gridlines
+      let grid = "";
+      const ticks = [0, 0.5, 1, 1.5, 2, 2.5].filter(t => t <= yMax);
+      ticks.forEach(t => {
+        grid += `<line x1="${padL}" y1="${Y(t)}" x2="${W - padR}" y2="${Y(t)}" stroke="#f0f0f0" stroke-width="1"/>`;
+        grid += `<text x="${padL - 6}" y="${Y(t) + 3}" font-size="9" text-anchor="end">${t}</text>`;
+      });
+      // target entropy line
+      const targetLine =
+        `<line x1="${padL}" y1="${Y(Htarget)}" x2="${W - padR}" y2="${Y(Htarget)}" stroke="#27ae60" stroke-width="2" stroke-dasharray="6 4"/>` +
+        `<text x="${W - padR}" y="${Y(Htarget) - 5}" font-size="10" text-anchor="end" fill="#27ae60">H = ${Htarget.toFixed(2)}</text>`;
+      // running-average path
+      let d = "";
+      hist.forEach((v, k) => { d += (k === 0 ? "M" : "L") + X(k).toFixed(1) + " " + Y(v).toFixed(1) + " "; });
+      const trace = hist.length ? `<path d="${d}" fill="none" stroke="#8e44ad" stroke-width="2"/>` : "";
+      const dot = hist.length ? `<circle cx="${X(hist.length - 1).toFixed(1)}" cy="${Y(hist[hist.length - 1]).toFixed(1)}" r="3.5" fill="#8e44ad"/>` : "";
+      svg.innerHTML = grid + targetLine + trace + dot +
+        `<text x="${padL}" y="${H - 4}" font-size="9" opacity="0.6">draws →</text>`;
+    }
+
+    let acc = 0, last = 0;
+    function loop(t) {
+      if (!running) return;
+      if (!last) last = t;
+      acc += t - last; last = t;
+      while (acc > 18) { drawOne(); acc -= 18; }   // ~ a handful of draws per frame
+      draw();
+      raf = requestAnimationFrame(loop);
+    }
+    function start() { running = true; runBtn.textContent = "⏸ Pause"; last = 0; acc = 0; raf = requestAnimationFrame(loop); }
+    function stop() { running = false; runBtn.textContent = "▶ Run sampler"; if (raf) cancelAnimationFrame(raf); }
+
+    runBtn.addEventListener("click", () => { running ? stop() : start(); });
+    document.getElementById("se4-step").addEventListener("click", () => { for (let i = 0; i < 25; i++) drawOne(); draw(); });
+    document.getElementById("se4-reset").addEventListener("click", reset);
+
+    // when the distribution changes, the target line moves; redraw (keeps history for contrast)
+    dist.listeners.push(draw);
+    draw();
+  })();
+})();
+</script>

--- a/docs/posts.html
+++ b/docs/posts.html
@@ -1,12 +1,12 @@
 ---
-title: Blog | Thoughts & Insights
-permalink: "/blog/"
+title: Study Notes | Interactive Explainers
+permalink: "/study-notes/"
 layout: default
 ---
 
 <div class="blog-header">
-  <h1>Blog</h1>
-  <p class="blog-description">Exploring the intersection of technology, AI, and software engineering through thoughtful insights and experiences.</p>
+  <h1>Study Notes</h1>
+  <p class="blog-description">Interactive, hands-on explainers of ideas in machine learning and math — built to be poked, dragged, and run.</p>
 </div>
 
 <div class="posts">


### PR DESCRIPTION
Rename the "Blog" nav/section to "Study Notes" (/blog/ -> /study-notes/),
which better reflects that it holds interactive visual explainers rather
than traditional posts. Existing post URLs are unaffected (they use
/:title/ permalinks).

Add a new self-contained interactive study note on Shannon entropy with
four linked demos: information content (-log2 p), the biased-coin entropy
curve, an adjustable distribution explorer, and a sampler whose running
average surprise converges onto the entropy. Vanilla JS + inline SVG,
matching the existing notes' style and light/dark themes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012TvpYECpe8uooK2HepUAj4