### PR TITLE
Redesign study notes with a sleek, futuristic design system

### DIFF
--- a/docs/_includes/study-note-styles.html
+++ b/docs/_includes/study-note-styles.html
@@ -1,0 +1,267 @@
+<style>
+/* ============================================================
+   Study Notes — shared design system
+   Sleek/futuristic: cyan-teal accent, hairline borders, flat
+   single-accent controls, monospace numerals, glow in dark only.
+   Adaptive light + dark via tokens. Every selector is scoped
+   under .study-note so nothing leaks to the rest of the site.
+   ============================================================ */
+.study-note {
+  --sn-accent: #0891b2;
+  --sn-accent-strong: #06b6d4;
+  --sn-accent-soft: rgba(8, 145, 178, 0.10);
+  --sn-accent-line: rgba(8, 145, 178, 0.30);
+  --sn-on-accent: #ffffff;
+
+  --sn-panel: #ffffff;
+  --sn-panel-inset: #f6f8fa;
+  --sn-section: #f7f9fb;
+  --sn-border: rgba(15, 23, 42, 0.08);
+  --sn-grid: rgba(15, 23, 42, 0.10);
+
+  --sn-text: #1f2933;
+  --sn-muted: #64748b;
+
+  --sn-good: #0f9d8c;  --sn-good-bg: rgba(15, 157, 140, 0.10);
+  --sn-warn: #b07d18;  --sn-warn-bg: rgba(176, 125, 24, 0.10);
+  --sn-bad:  #b4544b;  --sn-bad-bg:  rgba(180, 84, 75, 0.10);
+
+  --sn-radius: 12px;
+  --sn-radius-sm: 8px;
+  --sn-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 4px 16px rgba(15, 23, 42, 0.05);
+  --sn-ease: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --sn-glow: none;
+  --sn-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace;
+}
+.dark-theme .study-note {
+  --sn-accent: #22d3ee;
+  --sn-accent-strong: #67e8f9;
+  --sn-accent-soft: rgba(34, 211, 238, 0.12);
+  --sn-accent-line: rgba(34, 211, 238, 0.35);
+  --sn-on-accent: #06141a;
+
+  --sn-panel: #11131c;
+  --sn-panel-inset: #161a26;
+  --sn-section: #14161f;
+  --sn-border: rgba(148, 163, 184, 0.14);
+  --sn-grid: rgba(148, 163, 184, 0.16);
+
+  --sn-text: #e2e8f0;
+  --sn-muted: #94a3b8;
+
+  --sn-good: #34d399;  --sn-good-bg: rgba(52, 211, 153, 0.12);
+  --sn-warn: #e2b04a;  --sn-warn-bg: rgba(226, 176, 74, 0.12);
+  --sn-bad:  #f0857c;  --sn-bad-bg:  rgba(240, 133, 124, 0.12);
+
+  --sn-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --sn-glow: 0 0 0 1px var(--sn-accent-line), 0 0 16px rgba(34, 211, 238, 0.18);
+}
+
+/* ---- sections / cards ---- */
+.study-note .se-section,
+.study-note .bm-section,
+.study-note .mdp-section {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: var(--sn-radius);
+  background: var(--sn-section);
+  border: 1px solid var(--sn-border);
+  box-shadow: var(--sn-shadow);
+}
+.study-note .se-section h3,
+.study-note .bm-section h3,
+.study-note .mdp-section h3 {
+  margin-top: 0;
+  color: var(--sn-accent);
+  letter-spacing: -0.01em;
+}
+
+/* ---- equation boxes ---- */
+.study-note .se-equation,
+.study-note .bm-equation,
+.study-note .equation-box {
+  padding: 1rem 1.5rem;
+  margin: 1rem 0;
+  background: var(--sn-panel);
+  border: 1px solid var(--sn-border);
+  border-radius: var(--sn-radius-sm);
+  font-size: 1.1rem;
+  text-align: center;
+  overflow-x: auto;
+}
+.study-note .se-equation .big,
+.study-note .bm-equation .big { font-size: 1.25rem; }
+
+/* ---- callout / note ---- */
+.study-note .se-note,
+.study-note .bm-note {
+  background: var(--sn-accent-soft);
+  border-radius: var(--sn-radius-sm);
+  border-left: 3px solid var(--sn-accent);
+  padding: 0.9rem 1.1rem;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}
+
+/* ---- example box ---- */
+.study-note .se-example,
+.study-note .bm-example,
+.study-note .example-box {
+  background: var(--sn-panel-inset);
+  border: 1px solid var(--sn-border);
+  border-left: 3px solid var(--sn-warn);
+  border-radius: var(--sn-radius-sm);
+  padding: 1rem;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}
+
+/* ---- chart containers ---- */
+.study-note .se-chartwrap,
+.study-note .bm-chartwrap,
+.study-note .graph-wrap {
+  background: var(--sn-panel);
+  border: 1px solid var(--sn-border);
+  border-radius: var(--sn-radius-sm);
+  padding: 0.5rem;
+}
+.study-note .graph-wrap { overflow-x: auto; }
+
+/* ---- primary buttons ---- */
+.study-note .se-btn,
+.study-note .bm-btn,
+.study-note .vi-btn {
+  padding: 0.5rem 1.1rem;
+  border: none;
+  border-radius: var(--sn-radius-sm);
+  font-size: 0.9rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  color: var(--sn-on-accent);
+  background: var(--sn-accent);
+  transition: transform 0.15s var(--sn-ease), box-shadow 0.2s var(--sn-ease), background 0.2s var(--sn-ease);
+}
+.study-note .se-btn:hover:not(:disabled),
+.study-note .bm-btn:hover:not(:disabled),
+.study-note .vi-btn:hover:not(:disabled) {
+  background: var(--sn-accent-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--sn-glow);
+}
+.study-note .se-btn:disabled,
+.study-note .bm-btn:disabled,
+.study-note .vi-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+/* secondary variant */
+.study-note .se-btn.sec,
+.study-note .bm-btn.sec,
+.study-note .vi-btn.sec {
+  background: transparent;
+  color: var(--sn-accent);
+  box-shadow: inset 0 0 0 1px var(--sn-accent-line);
+}
+.study-note .se-btn.sec:hover:not(:disabled),
+.study-note .bm-btn.sec:hover:not(:disabled),
+.study-note .vi-btn.sec:hover:not(:disabled) {
+  background: var(--sn-accent-soft);
+  color: var(--sn-accent);
+}
+
+/* ---- ghost / reset buttons ---- */
+.study-note .se-reset,
+.study-note .bm-reset,
+.study-note .reset-link {
+  background: none;
+  border: 1px solid var(--sn-border);
+  border-radius: var(--sn-radius-sm);
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  color: var(--sn-muted);
+  transition: background 0.15s var(--sn-ease), border-color 0.15s var(--sn-ease), color 0.15s var(--sn-ease);
+}
+.study-note .se-reset:hover,
+.study-note .bm-reset:hover,
+.study-note .reset-link:hover {
+  background: var(--sn-accent-soft);
+  border-color: var(--sn-accent-line);
+  color: var(--sn-accent);
+}
+
+/* ---- range sliders: flat, single-accent ---- */
+.study-note input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--sn-border);
+  outline: none;
+  cursor: pointer;
+}
+.study-note input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--sn-accent);
+  border: none;
+  box-shadow: 0 0 0 4px var(--sn-accent-soft);
+  transition: transform 0.15s var(--sn-ease), box-shadow 0.15s var(--sn-ease);
+}
+.study-note input[type="range"]::-webkit-slider-thumb:hover { transform: scale(1.15); }
+.study-note input[type="range"]::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--sn-accent);
+  border: none;
+  box-shadow: 0 0 0 4px var(--sn-accent-soft);
+}
+.study-note input[type="range"]::-moz-range-track {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--sn-border);
+}
+
+/* ---- status pills ---- */
+.study-note .se-tag,
+.study-note .bm-tag {
+  display: inline-block;
+  padding: 0.22rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: var(--sn-accent-soft);
+  color: var(--sn-accent);
+  transition: background 0.2s var(--sn-ease), color 0.2s var(--sn-ease);
+}
+.study-note .se-tag.good, .study-note .bm-tag.good { background: var(--sn-good-bg); color: var(--sn-good); }
+.study-note .se-tag.warn, .study-note .bm-tag.warn { background: var(--sn-warn-bg); color: var(--sn-warn); }
+.study-note .se-tag.hot,  .study-note .bm-tag.hot  { background: var(--sn-bad-bg);  color: var(--sn-bad); }
+
+/* ---- numerals: monospace, tabular, accent (size kept per-note) ---- */
+.study-note .se-stat .val,
+.study-note .bm-stat .val,
+.study-note .score-item .sval,
+.study-note .compare-score {
+  font-family: var(--sn-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--sn-accent);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+.study-note .se-readout,
+.study-note .bm-temp-readout {
+  font-family: var(--sn-mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--sn-accent);
+}
+
+/* ---- svg text (scoped; replaces the old leaky global rule) ---- */
+.study-note svg text { fill: var(--sn-muted); }
+</style>

--- a/docs/_posts/2026-05-21-finding-optimal-policies-mdp.html
+++ b/docs/_posts/2026-05-21-finding-optimal-policies-mdp.html
@@ -6,21 +6,13 @@ categories: [Reinforcement Learning, Interactive]
 excerpt: "What should a 3rd grader do after school — study, play, or rest? Turns out this is a Markov Decision Process, and we can solve it optimally. An interactive introduction to MDPs and value iteration."
 ---
 
-<style>
-.mdp-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border-radius: 12px;
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
-}
-.dark-theme .mdp-section {
-  background: #1e1e2e;
-  border-color: #313244;
-}
-.mdp-section h3 { margin-top: 0; color: #2980b9; }
-.dark-theme .mdp-section h3 { color: #7ec8e3; }
+{% include study-note-styles.html %}
 
+<div class="study-note">
+
+<style>
+/* Note-specific layout. Shared components (sections, buttons, equations,
+   example boxes, ghost buttons, numerals, charts) live in study-note-styles.html. */
 .concept-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
@@ -29,12 +21,12 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
 }
 .concept-card {
   padding: 0.9rem;
-  border-radius: 8px;
-  border-left: 4px solid #4a90e2;
-  background: #fff;
+  border-radius: var(--sn-radius-sm);
+  border: 1px solid var(--sn-border);
+  border-left: 3px solid var(--sn-accent);
+  background: var(--sn-panel);
   font-size: 0.9rem;
 }
-.dark-theme .concept-card { background: #252535; }
 .concept-card .clabel {
   font-size: 0.7rem;
   text-transform: uppercase;
@@ -52,65 +44,52 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
   border-radius: 999px;
   font-size: 0.85rem;
   font-weight: 600;
-  background: #e8f4fd;
-  color: #1a5276;
-  border: 1px solid #aed6f1;
+  background: var(--sn-accent-soft);
+  color: var(--sn-accent);
+  border: 1px solid var(--sn-accent-line);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all 0.15s var(--sn-ease);
   font-family: inherit;
 }
 .state-badge:hover, .state-badge.active {
-  background: #2980b9;
-  color: white;
-  border-color: #2980b9;
+  background: var(--sn-accent);
+  color: var(--sn-on-accent);
+  border-color: var(--sn-accent);
 }
-.dark-theme .state-badge { background: #1a2634; color: #7ec8e3; border-color: #2a4a6a; }
-.dark-theme .state-badge.active { background: #2980b9; color: white; }
 
 .action-btn {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.55rem 1.1rem;
-  border-radius: 8px;
-  border: 2px solid #ccc;
+  border-radius: var(--sn-radius-sm);
+  border: 1px solid var(--sn-border);
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s;
-  background: #f5f5f5;
-  color: #333;
+  transition: all 0.15s var(--sn-ease);
+  background: var(--sn-panel-inset);
+  color: var(--sn-text);
   font-family: inherit;
 }
-.dark-theme .action-btn { background: #252535; color: #ccc; border-color: #444; }
-.action-btn:hover:not(:disabled) { filter: brightness(0.92); }
+.action-btn:hover:not(:disabled) { border-color: var(--sn-accent-line); }
 .action-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.action-btn[data-action="0"] { border-color: #4a90e2; }
-.action-btn[data-action="0"].active { background: #4a90e2; color: white; border-color: #4a90e2; }
-.action-btn[data-action="1"] { border-color: #e74c3c; }
-.action-btn[data-action="1"].active { background: #e74c3c; color: white; border-color: #e74c3c; }
-.action-btn[data-action="2"] { border-color: #27ae60; }
-.action-btn[data-action="2"].active { background: #27ae60; color: white; border-color: #27ae60; }
-
-.graph-wrap {
-  overflow-x: auto;
-  border-radius: 8px;
-  background: #fafafa;
-  border: 1px solid #eee;
-  padding: 0.5rem;
-}
-.dark-theme .graph-wrap { background: #14141e; border-color: #2a2a3e; }
+.action-btn[data-action="0"] { border-color: var(--sn-accent-line); }
+.action-btn[data-action="0"].active { background: var(--sn-accent); color: var(--sn-on-accent); border-color: var(--sn-accent); }
+.action-btn[data-action="1"] { border-color: rgba(180, 84, 75, 0.4); }
+.action-btn[data-action="1"].active { background: var(--sn-bad); color: #fff; border-color: var(--sn-bad); }
+.action-btn[data-action="2"] { border-color: rgba(15, 157, 140, 0.4); }
+.action-btn[data-action="2"].active { background: var(--sn-good); color: #fff; border-color: var(--sn-good); }
 
 .transition-info {
   margin-top: 0.75rem;
   padding: 0.85rem 1rem;
-  border-radius: 8px;
-  background: #f0f8ff;
-  border: 1px solid #b8d4f0;
+  border-radius: var(--sn-radius-sm);
+  background: var(--sn-accent-soft);
+  border: 1px solid var(--sn-accent-line);
   min-height: 70px;
   font-size: 0.9rem;
 }
-.dark-theme .transition-info { background: #1a2634; border-color: #2a4a6a; }
 
 .prob-row { display: flex; align-items: center; gap: 0.5rem; margin: 0.25rem 0; }
 .prob-bar { height: 16px; border-radius: 4px; transition: width 0.3s; opacity: 0.85; }
@@ -118,13 +97,12 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
 .play-display {
   text-align: center;
   padding: 1.25rem;
-  border-radius: 10px;
-  background: white;
-  border: 2px solid #e0e0e0;
+  border-radius: var(--sn-radius);
+  background: var(--sn-panel);
+  border: 1px solid var(--sn-border);
   margin-bottom: 0.75rem;
   transition: border-color 0.3s;
 }
-.dark-theme .play-display { background: #1a1a2a; border-color: #333; }
 .play-emoji { font-size: 3.5rem; line-height: 1; }
 .play-name { font-size: 1.4rem; font-weight: 700; margin: 0.4rem 0 0.2rem; }
 .play-desc { opacity: 0.6; font-size: 0.85rem; }
@@ -137,64 +115,24 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
 }
 .score-item { text-align: center; }
 .score-item .slabel { font-size: 0.7rem; text-transform: uppercase; opacity: 0.55; }
-.score-item .sval { font-size: 2rem; font-weight: 700; color: #2980b9; }
+.score-item .sval { font-size: 2rem; }
 
 .action-row { display: flex; gap: 0.6rem; justify-content: center; flex-wrap: wrap; margin: 0.75rem 0; }
 
 .play-log {
   max-height: 180px;
   overflow-y: auto;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
+  border: 1px solid var(--sn-border);
+  border-radius: var(--sn-radius-sm);
   padding: 0.4rem 0.6rem;
   font-size: 0.82rem;
-  font-family: monospace;
+  font-family: var(--sn-mono);
 }
-.dark-theme .play-log { border-color: #333; }
-.log-entry { padding: 0.15rem 0; border-bottom: 1px solid #f0f0f0; }
-.dark-theme .log-entry { border-bottom-color: #2a2a3a; }
-.lg { color: #27ae60; font-weight: 600; }
-.lbad { color: #e74c3c; }
-
-.equation-box {
-  padding: 1rem 1.5rem;
-  background: #f8f9fa;
-  border-radius: 8px;
-  border: 1px solid #dee2e6;
-  font-size: 1.1rem;
-  text-align: center;
-  margin: 1rem 0;
-  font-style: italic;
-  overflow-x: auto;
-}
-.dark-theme .equation-box { background: #1e1e2e; border-color: #313244; }
-
-.example-box {
-  background: #fff8e1;
-  border-radius: 8px;
-  padding: 1rem;
-  border: 1px solid #ffe082;
-  font-size: 0.9rem;
-  margin: 1rem 0;
-}
-.dark-theme .example-box { background: #2a2500; border-color: #554400; }
+.log-entry { padding: 0.15rem 0; border-bottom: 1px solid var(--sn-border); }
+.lg { color: var(--sn-good); font-weight: 600; }
+.lbad { color: var(--sn-bad); }
 
 .vi-controls { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin-bottom: 0.75rem; }
-.vi-btn {
-  padding: 0.45rem 1.1rem;
-  border-radius: 8px;
-  border: none;
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s;
-  background: #2980b9;
-  color: white;
-  font-family: inherit;
-}
-.vi-btn.sec { background: #7f8c8d; }
-.vi-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.vi-btn:hover:not(:disabled) { filter: brightness(0.88); }
 
 .vi-chart {
   display: flex;
@@ -202,51 +140,32 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
   align-items: flex-end;
   height: 160px;
   padding-bottom: 0.25rem;
-  border-bottom: 2px solid #ddd;
+  border-bottom: 1px solid var(--sn-border);
   margin-bottom: 0.75rem;
 }
-.dark-theme .vi-chart { border-bottom-color: #444; }
 .vi-bar-group { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 0.2rem; }
 .vi-bar { width: 100%; border-radius: 4px 4px 0 0; transition: height 0.35s ease, background 0.35s; min-height: 2px; }
-.vi-bv { font-size: 0.72rem; font-weight: 700; text-align: center; }
+.vi-bv { font-size: 0.72rem; font-weight: 700; text-align: center; font-family: var(--sn-mono); }
 .vi-be { font-size: 1rem; text-align: center; }
 .vi-bn { font-size: 0.62rem; opacity: 0.65; text-align: center; }
 
 .vi-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; margin-top: 0.5rem; }
-.vi-table th, .vi-table td { padding: 0.35rem 0.5rem; border: 1px solid #ddd; text-align: center; }
-.dark-theme .vi-table th, .dark-theme .vi-table td { border-color: #444; }
-.vi-table th { background: #f0f0f0; font-weight: 600; }
-.dark-theme .vi-table th { background: #252535; }
-.vi-table td.best { background: #e8f8e8; font-weight: 700; }
-.dark-theme .vi-table td.best { background: #1a3a1a; }
+.vi-table th, .vi-table td { padding: 0.35rem 0.5rem; border: 1px solid var(--sn-border); text-align: center; }
+.vi-table th { background: var(--sn-panel-inset); font-weight: 600; }
+.vi-table td.best { background: var(--sn-good-bg); color: var(--sn-good); font-weight: 700; }
 
 .policy-table { width: 100%; border-collapse: collapse; font-size: 0.88rem; }
-.policy-table th, .policy-table td { padding: 0.45rem 0.65rem; border: 1px solid #ddd; text-align: center; }
-.dark-theme .policy-table th, .dark-theme .policy-table td { border-color: #444; }
-.policy-table th { background: #f0f0f0; }
-.dark-theme .policy-table th { background: #252535; }
+.policy-table th, .policy-table td { padding: 0.45rem 0.65rem; border: 1px solid var(--sn-border); text-align: center; }
+.policy-table th { background: var(--sn-panel-inset); }
 .policy-table td:last-child { text-align: left; font-size: 0.78rem; opacity: 0.75; }
 
 .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1rem; }
-.compare-box { padding: 1rem; border-radius: 10px; border: 2px solid; text-align: center; }
-.compare-box.yours { border-color: #e74c3c; }
-.compare-box.opt { border-color: #27ae60; }
-.compare-score { font-size: 2.5rem; font-weight: 700; margin: 0.4rem 0; }
-.compare-box.yours .compare-score { color: #e74c3c; }
-.compare-box.opt .compare-score { color: #27ae60; }
-
-.reset-link {
-  background: none;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  padding: 0.3rem 0.75rem;
-  font-size: 0.82rem;
-  cursor: pointer;
-  font-family: inherit;
-  transition: background 0.15s;
-}
-.reset-link:hover { background: #f0f0f0; }
-.dark-theme .reset-link:hover { background: #252535; }
+.compare-box { padding: 1rem; border-radius: var(--sn-radius); border: 1px solid var(--sn-border); text-align: center; }
+.compare-box.yours { border-color: rgba(180, 84, 75, 0.45); }
+.compare-box.opt { border-color: rgba(15, 157, 140, 0.45); }
+.compare-score { font-size: 2.5rem; margin: 0.4rem 0; }
+.compare-box.yours .compare-score { color: var(--sn-bad); }
+.compare-box.opt .compare-score { color: var(--sn-good); }
 
 .flex-row { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
 .mb1 { margin-bottom: 0.5rem; }
@@ -275,12 +194,12 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
   <p style="margin-top:0">Every MDP is defined by four things. Here's how they map to Luca's life:</p>
 
   <div class="concept-grid">
-    <div class="concept-card" style="border-left-color:#4a90e2">
+    <div class="concept-card" style="border-left-color:var(--sn-accent)">
       <div class="clabel">States S</div>
       Luca's situation, captured as his <strong>energy &amp; grade level</strong>.<br><br>
       😴 Exhausted &rarr; 😐 Tired &rarr; 🙂 Balanced &rarr; 💪 Focused &rarr; ⭐ Star
     </div>
-    <div class="concept-card" style="border-left-color:#e74c3c">
+    <div class="concept-card" style="border-left-color:var(--sn-bad)">
       <div class="clabel">Actions A &amp; Rewards R(s,a)</div>
       Three choices each afternoon — but the happiness they bring <strong>depends on Luca's state</strong>. A Star Student enjoys everything more:<br><br>
       <small>
@@ -294,11 +213,11 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
       </table>
       </small>
     </div>
-    <div class="concept-card" style="border-left-color:#9b59b6">
+    <div class="concept-card" style="border-left-color:var(--sn-warn)">
       <div class="clabel">Transitions P(s'|s,a)</div>
       Life is <strong>stochastic</strong>. Studying doesn't guarantee improvement — Luca might be too tired, or the test might be hard. Each action leads to next states with specific <em>probabilities</em>.
     </div>
-    <div class="concept-card" style="border-left-color:#27ae60">
+    <div class="concept-card" style="border-left-color:var(--sn-good)">
       <div class="clabel">Discount factor γ = 0.9</div>
       Future happiness is worth slightly less than today's — not because it matters less, but because there's uncertainty about reaching that future. A reward tomorrow is worth 0.9× a reward today.
     </div>
@@ -367,7 +286,7 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
   <div class="action-row" id="play-btns"></div>
 
   <div class="play-log" id="play-log"></div>
-  <div id="play-result" style="display:none;margin-top:0.75rem;padding:1rem;border-radius:8px;border:2px solid #2980b9;text-align:center"></div>
+  <div id="play-result" style="display:none;margin-top:0.75rem;padding:1rem;border-radius:8px;border:1px solid var(--sn-accent);text-align:center"></div>
   <div style="margin-top:0.6rem"><button class="reset-link" id="play-reset">↺ Reset</button></div>
 </div>
 
@@ -425,6 +344,26 @@ excerpt: "What should a 3rd grader do after school — study, play, or rest? Tur
 // ─────────────────────────────────────────────────────────────
 //  MDP DEFINITION
 // ─────────────────────────────────────────────────────────────
+// theme-aware colors: read CSS tokens, re-read + recolor on light/dark toggle
+const SN = document.querySelector(".study-note");
+const readCols = () => {
+  const cs = getComputedStyle(SN);
+  const c = n => cs.getPropertyValue(n).trim();
+  return { accent: c("--sn-accent"), good: c("--sn-good"), bad: c("--sn-bad"),
+           warn: c("--sn-warn"), muted: c("--sn-muted"), grid: c("--sn-grid"),
+           softbg: c("--sn-accent-soft") };
+};
+let COL = readCols();
+const redrawFns = [];
+const onTheme = fn => { redrawFns.push(fn); return fn; };
+function updateActionColors() {
+  ACTIONS[0].color = COL.accent;
+  ACTIONS[1].color = COL.bad;
+  ACTIONS[2].color = COL.good;
+}
+new MutationObserver(() => { COL = readCols(); updateActionColors(); redrawFns.forEach(f => f()); })
+  .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+
 const STATES = [
   { id: 0, name: "Exhausted", emoji: "😴", desc: "Burnt out, grades slipping" },
   { id: 1, name: "Tired",     emoji: "😐", desc: "Low energy, getting by" },
@@ -434,9 +373,9 @@ const STATES = [
 ];
 
 const ACTIONS = [
-  { id: 0, name: "Study", emoji: "📚", color: "#4a90e2" },
-  { id: 1, name: "Play",  emoji: "🎮", color: "#e74c3c" },
-  { id: 2, name: "Rest",  emoji: "💤", color: "#27ae60" }
+  { id: 0, name: "Study", emoji: "📚", color: COL.accent },
+  { id: 1, name: "Play",  emoji: "🎮", color: COL.bad },
+  { id: 2, name: "Rest",  emoji: "💤", color: COL.good }
 ];
 
 // REWARDS[state][action]: happiness = state wellbeing + action base
@@ -517,7 +456,7 @@ function policy(V) {
 
   // Arrowhead markers
   const defs = document.createElementNS(NS, 'defs');
-  [...ACTIONS, {id:'gray', color:'#bbb'}].forEach(a => {
+  [...ACTIONS, {id:'gray', color: COL.muted}].forEach(a => {
     const m = document.createElementNS(NS, 'marker');
     m.setAttribute('id', `arr${a.id}`);
     m.setAttribute('markerWidth','10'); m.setAttribute('markerHeight','7');
@@ -541,8 +480,8 @@ function policy(V) {
 
     const c = document.createElementNS(NS, 'circle');
     c.setAttribute('cx', POS[st.id].x); c.setAttribute('cy', POS[st.id].y);
-    c.setAttribute('r', R); c.setAttribute('fill', '#e8f4fd');
-    c.setAttribute('stroke','#4a90e2'); c.setAttribute('stroke-width','2');
+    c.setAttribute('r', R); c.setAttribute('fill', COL.softbg);
+    c.setAttribute('stroke', COL.accent); c.setAttribute('stroke-width','2');
     c.setAttribute('id', 'nc'+st.id);
 
     const em = document.createElementNS(NS, 'text');
@@ -553,7 +492,7 @@ function policy(V) {
     const lbl = document.createElementNS(NS, 'text');
     lbl.setAttribute('x', POS[st.id].x); lbl.setAttribute('y', POS[st.id].y + 16);
     lbl.setAttribute('text-anchor','middle'); lbl.setAttribute('font-size','10');
-    lbl.setAttribute('fill','#555'); lbl.setAttribute('id','nl'+st.id);
+    lbl.setAttribute('fill', COL.muted); lbl.setAttribute('id','nl'+st.id);
     lbl.textContent = st.name;
 
     g.appendChild(c); g.appendChild(em); g.appendChild(lbl);
@@ -589,11 +528,11 @@ function policy(V) {
       const nc = document.getElementById('nc'+st.id);
       const nl = document.getElementById('nl'+st.id);
       if (st.id === id) {
-        nc.setAttribute('fill','#2980b9'); nc.setAttribute('stroke','#1a5276');
+        nc.setAttribute('fill', COL.accent); nc.setAttribute('stroke', COL.accent);
         nl.setAttribute('fill','#fff');
       } else {
-        nc.setAttribute('fill','#e8f4fd'); nc.setAttribute('stroke','#4a90e2');
-        nl.setAttribute('fill','#555');
+        nc.setAttribute('fill', COL.softbg); nc.setAttribute('stroke', COL.accent);
+        nl.setAttribute('fill', COL.muted);
       }
     });
     render();
@@ -682,6 +621,18 @@ function policy(V) {
     lbl.textContent = Math.round(p*100)+'%';
     arrowLayer.appendChild(lbl);
   }
+
+  onTheme(() => {
+    ACTIONS.forEach(a => { const poly = document.querySelector(`#arr${a.id} polygon`); if (poly) poly.setAttribute('fill', a.color); });
+    const gpoly = document.querySelector('#arrgray polygon'); if (gpoly) gpoly.setAttribute('fill', COL.muted);
+    STATES.forEach(st => {
+      const nc = document.getElementById('nc'+st.id);
+      const nl = document.getElementById('nl'+st.id);
+      if (st.id === selState) { nc.setAttribute('fill', COL.accent); nc.setAttribute('stroke', COL.accent); nl.setAttribute('fill', '#fff'); }
+      else { nc.setAttribute('fill', COL.softbg); nc.setAttribute('stroke', COL.accent); nl.setAttribute('fill', COL.muted); }
+    });
+    render();
+  });
 })();
 
 // ─────────────────────────────────────────────────────────────
@@ -727,7 +678,7 @@ function makeMove(aId) {
     document.querySelectorAll('#play-btns .action-btn').forEach(b => b.disabled = true);
     const res = document.getElementById('play-result');
     res.style.display = 'block';
-    res.innerHTML = `<strong>10 days done!</strong> Your total happiness: <span style="font-size:1.5rem;font-weight:700;color:#2980b9">${play.score}</span><br><span style="opacity:0.65;font-size:0.88rem">Run value iteration to convergence below, then scroll down to see how you compare!</span>`;
+    res.innerHTML = `<strong>10 days done!</strong> Your total happiness: <span style="font-size:1.5rem;font-weight:700;color:${COL.accent}">${play.score}</span><br><span style="opacity:0.65;font-size:0.88rem">Run value iteration to convergence below, then scroll down to see how you compare!</span>`;
     tryShowComparison();
   }
   updatePlayUI();
@@ -858,6 +809,7 @@ document.getElementById('vi-reset').addEventListener('click', () => {
 });
 
 renderChart(); renderQTable();
+onTheme(() => { renderChart(); renderQTable(); if (vi.iter > 0) renderPolicy(); });
 
 // ─────────────────────────────────────────────────────────────
 //  COMPARISON
@@ -883,13 +835,13 @@ function tryShowComparison() {
   const verdict = document.getElementById('c-verdict');
   if (diff <= 0) {
     verdict.textContent = `🎉 You matched or beat the optimal policy! (by ${Math.abs(diff)} points)`;
-    verdict.style.color = '#27ae60';
+    verdict.style.color = COL.good;
   } else if (diff <= 6) {
     verdict.textContent = `👏 Very close! The optimal policy earned just ${diff} more points.`;
-    verdict.style.color = '#f39c12';
+    verdict.style.color = COL.warn;
   } else {
     verdict.textContent = `💡 The optimal policy earned ${diff} more points — look at which states it handled differently.`;
-    verdict.style.color = '#e74c3c';
+    verdict.style.color = COL.bad;
   }
 
   let html = `<table class="vi-table"><thead><tr>
@@ -903,10 +855,12 @@ function tryShowComparison() {
       <td>${ACTIONS[row.ya].emoji} ${ACTIONS[row.ya].name}</td>
       <td class="${changed?'best':''}">${ACTIONS[row.oa].emoji} ${ACTIONS[row.oa].name}</td>
       <td>+${row.yr}</td>
-      <td>${row.or > row.yr ? `<strong style="color:#27ae60">+${row.or}</strong>` : `+${row.or}`}</td>
+      <td>${row.or > row.yr ? `<strong style="color:${COL.good}">+${row.or}</strong>` : `+${row.or}`}</td>
     </tr>`;
   });
   html += '</tbody></table>';
   document.getElementById('c-table').innerHTML = html;
 }
 </script>
+
+</div>

--- a/docs/_posts/2026-05-30-boltzmann-machines-visually.html
+++ b/docs/_posts/2026-05-30-boltzmann-machines-visually.html
@@ -6,147 +6,51 @@ categories: [Machine Learning, Interactive]
 excerpt: "You already know Hopfield networks slide downhill into the nearest memory — and get stuck. Add a single ingredient, temperature, and that deterministic descent becomes a Boltzmann machine that samples, escapes local minima, and learns. A hands-on, visual refresher with live energy landscapes, annealing, and a trainable RBM."
 ---
 
+{% include study-note-styles.html %}
+
+<div class="study-note">
+
 <style>
-/* ===== layout ===== */
-.bm-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border-radius: 12px;
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
-}
-.dark-theme .bm-section { background: #1e1e2e; border-color: #313244; }
-.bm-section h3 { margin-top: 0; color: #8e44ad; }
-.dark-theme .bm-section h3 { color: #c8a2e8; }
+/* Note-specific layout. Shared components (sections, buttons, sliders,
+   tags, equations, notes, charts, numerals) live in study-note-styles.html. */
 .bm-section h4 { margin-bottom: 0.5rem; }
 
-.bm-equation {
-  padding: 1rem 1.5rem;
-  background: #fff;
-  border-radius: 8px;
-  border: 1px solid #dee2e6;
-  font-size: 1.1rem;
-  text-align: center;
-  margin: 1rem 0;
-  overflow-x: auto;
-}
-.dark-theme .bm-equation { background: #14141e; border-color: #313244; }
-.bm-equation .big { font-size: 1.25rem; }
-
-.bm-note {
-  background: #f3e9fb;
-  border-radius: 8px;
-  padding: 0.9rem 1.1rem;
-  border-left: 4px solid #8e44ad;
-  font-size: 0.9rem;
-  margin: 1rem 0;
-}
-.dark-theme .bm-note { background: #251a30; border-left-color: #c8a2e8; }
-
-.bm-example {
-  background: #fff8e1;
-  border-radius: 8px;
-  padding: 1rem;
-  border: 1px solid #ffe082;
-  font-size: 0.9rem;
-  margin: 1rem 0;
-}
-.dark-theme .bm-example { background: #2a2500; border-color: #554400; }
-
-/* ===== controls ===== */
 .bm-controls { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
-.bm-btn {
-  padding: 0.5rem 1.1rem;
-  border-radius: 8px;
-  border: none;
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s;
-  background: #8e44ad;
-  color: white;
-  font-family: inherit;
-}
-.bm-btn.sec { background: #5d6d7e; }
-.bm-btn:hover:not(:disabled) { filter: brightness(0.9); }
-.bm-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.bm-reset {
-  background: none;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  padding: 0.4rem 0.85rem;
-  font-size: 0.85rem;
-  cursor: pointer;
-  font-family: inherit;
-  transition: background 0.15s;
-}
-.bm-reset:hover { background: #eee; }
-.dark-theme .bm-reset { border-color: #444; color: #ccc; }
-.dark-theme .bm-reset:hover { background: #252535; }
-
-.bm-slider { -webkit-appearance: none; appearance: none; height: 6px; border-radius: 3px;
-  background: linear-gradient(90deg,#3498db,#e74c3c); outline: none; cursor: pointer; }
-.bm-slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 18px; height: 18px;
-  border-radius: 50%; background: #fff; border: 2px solid #8e44ad; cursor: pointer; }
-.bm-slider::-moz-range-thumb { width: 18px; height: 18px; border-radius: 50%; background: #fff;
-  border: 2px solid #8e44ad; cursor: pointer; }
-.bm-temp-readout { font-weight: 700; font-size: 1.05rem; min-width: 4.5rem; display: inline-block; }
+.bm-temp-readout { font-size: 1.05rem; min-width: 4.5rem; display: inline-block; }
 
 /* ===== grids of binary units ===== */
 .bm-grid { display: grid; gap: 4px; }
 .bm-cell {
   border-radius: 6px;
-  border: 2px solid #cfd6dd;
-  background: #fff;
+  border: 1px solid var(--sn-border);
+  background: var(--sn-panel-inset);
   cursor: pointer;
-  transition: background 0.18s, border-color 0.18s, transform 0.1s;
+  transition: background 0.18s var(--sn-ease), border-color 0.18s, transform 0.1s;
   padding: 0;
 }
-.dark-theme .bm-cell { background: #11111a; border-color: #2d2d40; }
-.bm-cell.on { background: #8e44ad; border-color: #6c3483; }
+.bm-cell.on { background: var(--sn-accent); border-color: var(--sn-accent); }
 .bm-cell:active { transform: scale(0.93); }
-.bm-cell.flash { box-shadow: 0 0 0 3px rgba(241,196,15,0.7); }
+.bm-cell.flash { box-shadow: 0 0 0 3px var(--sn-accent-line); }
 
 .bm-thumb { display: grid; gap: 2px; }
-.bm-thumb .tc { border-radius: 2px; background: #e3e8ee; }
-.dark-theme .bm-thumb .tc { background: #1d1d2c; }
-.bm-thumb .tc.on { background: #8e44ad; }
+.bm-thumb .tc { border-radius: 2px; background: var(--sn-panel-inset); }
+.bm-thumb .tc.on { background: var(--sn-accent); }
 
 .bm-flexwrap { display: flex; gap: 1.25rem; flex-wrap: wrap; align-items: flex-start; }
 .bm-panel { flex: 1; min-width: 240px; }
 
 .bm-stat { text-align: center; }
 .bm-stat .lab { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; }
-.bm-stat .val { font-size: 1.7rem; font-weight: 700; color: #8e44ad; line-height: 1.1; }
-.dark-theme .bm-stat .val { color: #c8a2e8; }
+.bm-stat .val { font-size: 1.7rem; }
 .bm-statrow { display: flex; gap: 2rem; justify-content: center; margin: 0.5rem 0; }
 
-.bm-tag {
-  display: inline-block; padding: 0.2rem 0.6rem; border-radius: 999px;
-  font-size: 0.8rem; font-weight: 600;
-}
-.bm-tag.good { background: #d5f5e3; color: #1e8449; }
-.bm-tag.warn { background: #fdebd0; color: #b9770e; }
-.bm-tag.hot  { background: #fadbd8; color: #c0392b; }
-.dark-theme .bm-tag.good { background: #14331f; color: #6fcf97; }
-.dark-theme .bm-tag.warn { background: #3a2c10; color: #f0b24a; }
-.dark-theme .bm-tag.hot  { background: #3a1714; color: #f1948a; }
-
-svg text { fill: #555; }
-.dark-theme svg text { fill: #bbb; }
-
-.bm-chartwrap { background: #fff; border: 1px solid #e6e6ee; border-radius: 8px; padding: 0.4rem; }
-.dark-theme .bm-chartwrap { background: #11111a; border-color: #2a2a3e; }
-
-.bm-segbtns { display: inline-flex; border-radius: 8px; overflow: hidden; border: 1px solid #8e44ad; }
+.bm-segbtns { display: inline-flex; border-radius: var(--sn-radius-sm); overflow: hidden; border: 1px solid var(--sn-accent-line); }
 .bm-segbtns button {
   background: transparent; border: none; padding: 0.45rem 0.9rem; cursor: pointer;
-  font-family: inherit; font-size: 0.85rem; font-weight: 600; color: #8e44ad;
+  font-family: inherit; font-size: 0.85rem; font-weight: 600; color: var(--sn-accent);
+  transition: background 0.15s var(--sn-ease), color 0.15s var(--sn-ease);
 }
-.bm-segbtns button.active { background: #8e44ad; color: #fff; }
-.dark-theme .bm-segbtns { border-color: #c8a2e8; }
-.dark-theme .bm-segbtns button { color: #c8a2e8; }
-.dark-theme .bm-segbtns button.active { background: #8e44ad; color: #fff; }
+.bm-segbtns button.active { background: var(--sn-accent); color: var(--sn-on-accent); }
 
 .bm-legend { font-size: 0.78rem; opacity: 0.75; display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 0.4rem; }
 .bm-legend span::before { content: "■ "; }
@@ -239,7 +143,7 @@ svg text { fill: #555; }
       <div class="bm-chartwrap">
         <svg id="bmA-chart" width="100%" height="120" viewBox="0 0 400 120" preserveAspectRatio="none" style="display:block"></svg>
       </div>
-      <div class="bm-legend"><span style="color:#8e44ad">energy over time</span></div>
+      <div class="bm-legend"><span style="color:var(--sn-accent)">energy over time</span></div>
     </div>
   </div>
 
@@ -316,8 +220,8 @@ svg text { fill: #555; }
     <svg id="bmC-svg" width="100%" height="240" viewBox="0 0 720 240"></svg>
   </div>
   <div class="bm-legend">
-    <span style="color:#1a5276">low energy (likely)</span>
-    <span style="color:#c0392b">high energy (rare)</span>
+    <span style="color:var(--sn-accent)">low energy (likely)</span>
+    <span style="color:var(--sn-bad)">high energy (rare)</span>
   </div>
 
   <div class="bm-flexwrap" style="margin-top:1rem">
@@ -363,8 +267,8 @@ svg text { fill: #555; }
         <svg id="bmD-svg" width="100%" height="180" viewBox="0 0 420 180"></svg>
       </div>
       <div class="bm-legend">
-        <span style="color:#8e44ad">energy</span>
-        <span style="color:#e67e22">temperature</span>
+        <span style="color:var(--sn-accent)">energy</span>
+        <span style="color:var(--sn-warn)">temperature</span>
       </div>
     </div>
   </div>
@@ -435,8 +339,8 @@ svg text { fill: #555; }
       <h4 style="margin-top:0">Hidden-unit receptive fields</h4>
       <div id="bmE-fields" style="display:flex;gap:0.8rem;flex-wrap:wrap"></div>
       <div class="bm-legend">
-        <span style="color:#c0392b">negative weight</span>
-        <span style="color:#2471a3">positive weight</span>
+        <span style="color:var(--sn-bad)">negative weight</span>
+        <span style="color:var(--sn-accent)">positive weight</span>
       </div>
     </div>
   </div>
@@ -487,6 +391,23 @@ svg text { fill: #555; }
 <script>
 (function () {
   "use strict";
+  // theme-aware colors: read CSS tokens, re-read + redraw on light/dark toggle
+  const SN = document.querySelector(".study-note");
+  const hex2rgb = h => { h = h.replace("#", ""); if (h.length === 3) h = h.split("").map(x => x + x).join(""); return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]; };
+  const mix = (a, b, t) => { const A = hex2rgb(a), B = hex2rgb(b); return `rgb(${A.map((v, i) => Math.round(v + (B[i] - v) * t)).join(",")})`; };
+  const readCols = () => {
+    const cs = getComputedStyle(SN);
+    const c = n => cs.getPropertyValue(n).trim();
+    return { accent: c("--sn-accent"), good: c("--sn-good"), bad: c("--sn-bad"),
+             warn: c("--sn-warn"), muted: c("--sn-muted"), grid: c("--sn-grid"),
+             inset: c("--sn-panel-inset"), line: c("--sn-accent-line") };
+  };
+  let COL = readCols();
+  const redrawFns = [];
+  const onTheme = fn => { redrawFns.push(fn); return fn; };
+  new MutationObserver(() => { COL = readCols(); redrawFns.forEach(f => f()); })
+    .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+
   const sigmoid = x => 1 / (1 + Math.exp(-x));
   const clamp = (x, a, b) => Math.max(a, Math.min(b, x));
 
@@ -588,9 +509,9 @@ svg text { fill: #555; }
       hist.forEach((e, k) => { d += (k === 0 ? "M" : "L") + (pad + k * xs).toFixed(1) + " " + y(e).toFixed(1) + " "; });
       const zeroY = y(0);
       svg.innerHTML =
-        `<line x1="${pad}" y1="${zeroY}" x2="${W_-pad}" y2="${zeroY}" stroke="#ccc" stroke-dasharray="3 3"/>` +
+        `<line x1="${pad}" y1="${zeroY}" x2="${W_-pad}" y2="${zeroY}" stroke="${COL.grid}" stroke-dasharray="3 3"/>` +
         `<text x="${pad+2}" y="${zeroY-3}" font-size="9" opacity="0.6">E=0</text>` +
-        `<path d="${d}" fill="none" stroke="#8e44ad" stroke-width="2"/>`;
+        `<path d="${d}" fill="none" stroke="${COL.accent}" stroke-width="2"/>`;
     }
 
     function pushHist(e) { hist.push(e); if (hist.length > 120) hist.shift(); }
@@ -649,6 +570,7 @@ svg text { fill: #555; }
 
     tval.textContent = tempOf().toFixed(2);
     pushHist(energy(s, HEB.W, HEB.b));
+    onTheme(paint);
     paint();
   })();
 
@@ -686,21 +608,21 @@ svg text { fill: #555; }
       // gridlines + axes
       let grid = "";
       [0, 0.25, 0.5, 0.75, 1].forEach(p2 => {
-        grid += `<line x1="${padL}" y1="${Y(p2)}" x2="${W_-padR}" y2="${Y(p2)}" stroke="#ddd" stroke-width="1"/>`;
+        grid += `<line x1="${padL}" y1="${Y(p2)}" x2="${W_-padR}" y2="${Y(p2)}" stroke="${COL.grid}" stroke-width="1"/>`;
         grid += `<text x="${padL-6}" y="${Y(p2)+3}" font-size="10" text-anchor="end">${p2}</text>`;
       });
       [-6,-3,0,3,6].forEach(x => {
-        grid += `<line x1="${X(x)}" y1="${padT}" x2="${X(x)}" y2="${H_-padB}" stroke="#eee" stroke-width="1"/>`;
+        grid += `<line x1="${X(x)}" y1="${padT}" x2="${X(x)}" y2="${H_-padB}" stroke="${COL.grid}" stroke-width="1"/>`;
         grid += `<text x="${X(x)}" y="${H_-padB+16}" font-size="10" text-anchor="middle">${x>0?"+":""}${x}</text>`;
       });
-      const half = `<line x1="${padL}" y1="${Y(0.5)}" x2="${W_-padR}" y2="${Y(0.5)}" stroke="#bbb" stroke-dasharray="4 4"/>`;
+      const half = `<line x1="${padL}" y1="${Y(0.5)}" x2="${W_-padR}" y2="${Y(0.5)}" stroke="${COL.muted}" stroke-dasharray="4 4"/>`;
       const marker =
-        `<line x1="${X(dE)}" y1="${padT}" x2="${X(dE)}" y2="${H_-padB}" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="3 3"/>` +
-        `<circle cx="${X(dE)}" cy="${Y(p)}" r="6" fill="#e74c3c"/>` +
-        `<text x="${X(dE)+9}" y="${Y(p)-6}" font-size="12" fill="#e74c3c" font-weight="700">p=${p.toFixed(2)}</text>`;
+        `<line x1="${X(dE)}" y1="${padT}" x2="${X(dE)}" y2="${H_-padB}" stroke="${COL.bad}" stroke-width="1.5" stroke-dasharray="3 3"/>` +
+        `<circle cx="${X(dE)}" cy="${Y(p)}" r="6" fill="${COL.bad}"/>` +
+        `<text x="${X(dE)+9}" y="${Y(p)-6}" font-size="12" fill="${COL.bad}" font-weight="700">p=${p.toFixed(2)}</text>`;
       svg.innerHTML =
         grid + half +
-        `<path d="${path}" fill="none" stroke="#8e44ad" stroke-width="2.5"/>` +
+        `<path d="${path}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>` +
         marker +
         `<text x="${X(0)}" y="${H_-4}" font-size="11" text-anchor="middle">energy saved by turning on  (&Delta;E)</text>` +
         `<text x="14" y="${padT+90}" font-size="11" transform="rotate(-90 14 ${padT+90})" text-anchor="middle">p(unit on)</text>`;
@@ -711,6 +633,7 @@ svg text { fill: #555; }
     }
     tempSlider.addEventListener("input", draw);
     deSlider.addEventListener("input", draw);
+    onTheme(draw);
     draw();
   })();
 
@@ -745,11 +668,8 @@ svg text { fill: #555; }
 
     function energyColor(e) {
       const t = (e - eLo) / (eHi - eLo + 1e-9); // 0 low ... 1 high
-      // interpolate blue(low) -> red(high)
-      const r = Math.round(26 + t * (192 - 26));
-      const g = Math.round(82 + t * (57 - 82));
-      const bl = Math.round(118 + t * (43 - 118));
-      return `rgb(${r},${g},${bl})`;
+      // interpolate accent (low energy) -> muted slate (high energy)
+      return mix(COL.accent, COL.muted, t);
     }
 
     function draw() {
@@ -773,14 +693,15 @@ svg text { fill: #555; }
         const gx = k * slot + slot/2, gy = H_ - padB + 8, cs = 7;
         for (let i = 0; i < n; i++) {
           const cx = gx - cs + (i % 2) * cs, cy = gy + Math.floor(i / 2) * cs;
-          out += `<rect x="${cx}" y="${cy}" width="${cs-1.5}" height="${cs-1.5}" rx="1" fill="${s.st[i]===1?'#8e44ad':'#d8dde3'}"/>`;
+          out += `<rect x="${cx}" y="${cy}" width="${cs-1.5}" height="${cs-1.5}" rx="1" fill="${s.st[i]===1?COL.accent:COL.inset}"/>`;
         }
       });
       // label global min
-      out += `<text x="${(0*slot+slot/2).toFixed(1)}" y="${H_-2}" font-size="9" text-anchor="middle" fill="#1a5276" font-weight="700">min E</text>`;
+      out += `<text x="${(0*slot+slot/2).toFixed(1)}" y="${H_-2}" font-size="9" text-anchor="middle" fill="${COL.accent}" font-weight="700">min E</text>`;
       svg.innerHTML = out;
     }
     tempSlider.addEventListener("input", draw);
+    onTheme(draw);
     draw();
   })();
 
@@ -824,7 +745,9 @@ svg text { fill: #555; }
 
     function paintGrid(s) { for (let i = 0; i < N; i++) cells[i].classList.toggle("on", s[i] === 1); }
 
+    let lastE = [], lastT = [];
     function drawTraces(eTrace, tTrace) {
+      lastE = eTrace; lastT = tTrace;
       const W_ = 420, H_ = 180, pad = 8;
       const K = eTrace.length;
       const eLo = -5.2, eHi = 3.2, tHi = 3.2;
@@ -835,8 +758,8 @@ svg text { fill: #555; }
       eTrace.forEach((e, k) => { de += (k===0?"M":"L") + (pad+k*xs).toFixed(1) + " " + yE(e).toFixed(1) + " "; });
       tTrace.forEach((t, k) => { dt += (k===0?"M":"L") + (pad+k*xs).toFixed(1) + " " + yT(t).toFixed(1) + " "; });
       svg.innerHTML =
-        `<path d="${dt}" fill="none" stroke="#e67e22" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.8"/>` +
-        `<path d="${de}" fill="none" stroke="#8e44ad" stroke-width="2.5"/>` +
+        `<path d="${dt}" fill="none" stroke="${COL.warn}" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.8"/>` +
+        `<path d="${de}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>` +
         `<text x="${W_-pad}" y="${yE(-5)}" font-size="9" text-anchor="end" opacity="0.6">deep memory</text>`;
     }
 
@@ -863,7 +786,7 @@ svg text { fill: #555; }
     document.getElementById("bmD-race").addEventListener("click", () => {
       const modes = ["greedy", "hot", "anneal"];
       const labels = { greedy: "Greedy (cold)", hot: "Always hot", anneal: "Annealed ❄️" };
-      const colors = { greedy: "#e74c3c", hot: "#e67e22", anneal: "#27ae60" };
+      const colors = { greedy: COL.bad, hot: COL.warn, anneal: COL.good };
       const res = {};
       modes.forEach(m => {
         let solved = 0;
@@ -880,7 +803,7 @@ svg text { fill: #555; }
         const pct = Math.round(res[m] * 100);
         return `<div style="display:flex;align-items:center;gap:0.6rem;margin:0.4rem 0">
           <span style="width:130px;font-size:0.85rem">${labels[m]}</span>
-          <div style="flex:1;background:#e8e8ef;border-radius:6px;overflow:hidden;height:22px;max-width:360px">
+          <div style="flex:1;background:${COL.inset};border-radius:6px;overflow:hidden;height:22px;max-width:360px">
             <div class="bm-pop" style="width:${pct}%;height:100%;background:${colors[m]};border-radius:6px"></div>
           </div>
           <strong style="width:3rem">${pct}%</strong>
@@ -891,6 +814,7 @@ svg text { fill: #555; }
     // initial
     const init = runOnce("anneal", true);
     paintGrid(init.s); drawTraces(init.eTrace, init.tTrace); setResult(init.s);
+    onTheme(() => drawTraces(lastE, lastT));
   })();
 
   // ============================================================
@@ -951,8 +875,8 @@ svg text { fill: #555; }
           const c = document.createElement("div");
           const w = Wt[i][j] / maxAbs; // -1..1
           let col;
-          if (w >= 0) { const t = w; col = `rgb(${Math.round(255-150*t)},${Math.round(255-100*t)},255)`; }
-          else { const t = -w; col = `rgb(255,${Math.round(255-150*t)},${Math.round(255-150*t)})`; }
+          if (w >= 0) { col = mix(COL.inset, COL.accent, w); }
+          else { col = mix(COL.inset, COL.bad, -w); }
           c.style.background = col;
           c.style.borderRadius = "2px";
           g.appendChild(c);
@@ -977,8 +901,8 @@ svg text { fill: #555; }
       let d="";
       errHist.forEach((e,k)=>{ d += (k===0?"M":"L")+(pad+k*xs).toFixed(1)+" "+y(e).toFixed(1)+" "; });
       errSvg.innerHTML =
-        `<path d="${d}" fill="none" stroke="#8e44ad" stroke-width="2"/>` +
-        `<text x="${W_-pad}" y="${y(errHist[errHist.length-1])-6}" font-size="10" text-anchor="end" fill="#8e44ad">${errHist[errHist.length-1].toFixed(2)}</text>` +
+        `<path d="${d}" fill="none" stroke="${COL.accent}" stroke-width="2"/>` +
+        `<text x="${W_-pad}" y="${y(errHist[errHist.length-1])-6}" font-size="10" text-anchor="end" fill="${COL.accent}">${errHist[errHist.length-1].toFixed(2)}</text>` +
         `<text x="${pad}" y="${H_-2}" font-size="9" opacity="0.6">epochs &rarr;</text>`;
     }
 
@@ -1018,7 +942,7 @@ svg text { fill: #555; }
     function paintVis() { for (let i=0;i<V;i++) visCells[i].classList.toggle("on", vState[i]===1); }
     function clearHidden() {
       hidEl.innerHTML = "";
-      for (let j=0;j<H;j++){ const b=document.createElement("div"); b.style.cssText="width:70px;height:14px;border-radius:7px;background:#e8e8ef"; hidEl.appendChild(b); }
+      for (let j=0;j<H;j++){ const b=document.createElement("div"); b.style.cssText=`width:70px;height:14px;border-radius:7px;background:${COL.inset}`; hidEl.appendChild(b); }
       recCells.forEach(c=>{ c.classList.remove("on"); c.style.background=""; });
     }
     function reconstruct() {
@@ -1026,9 +950,9 @@ svg text { fill: #555; }
       hidEl.innerHTML = "";
       for (let j=0;j<H;j++) {
         const outer = document.createElement("div");
-        outer.style.cssText = "width:70px;height:14px;border-radius:7px;background:#e8e8ef;overflow:hidden";
+        outer.style.cssText = `width:70px;height:14px;border-radius:7px;background:${COL.inset};overflow:hidden`;
         const inner = document.createElement("div");
-        inner.style.cssText = `width:${Math.round(hp[j]*100)}%;height:100%;background:#8e44ad;border-radius:7px`;
+        inner.style.cssText = `width:${Math.round(hp[j]*100)}%;height:100%;background:${COL.accent};border-radius:7px`;
         outer.appendChild(inner); hidEl.appendChild(outer);
       }
       const h = hp.map(bern);
@@ -1048,7 +972,7 @@ svg text { fill: #555; }
     document.getElementById("bmE-clear").addEventListener("click", () => { vState = new Array(V).fill(0); paintVis(); clearHidden(); });
 
     // ---- architecture diagram ----
-    (function () {
+    function drawArch() {
       const svg = document.getElementById("bmE-arch");
       const W_=460,H_=170;
       const vx = 120, hx = 340;
@@ -1057,17 +981,21 @@ svg text { fill: #555; }
       for (let j=0;j<H;j++) hys.push(40 + j*(H_-80)/(H-1));
       let s = "";
       for (let i=0;i<V;i++) for (let j=0;j<H;j++)
-        s += `<line x1="${vx}" y1="${vys[i]}" x2="${hx}" y2="${hys[j]}" stroke="#cdb4e0" stroke-width="0.6" opacity="0.7"/>`;
-      vys.forEach(y => s += `<circle cx="${vx}" cy="${y}" r="7" fill="#8e44ad"/>`);
-      hys.forEach(y => s += `<circle cx="${hx}" cy="${y}" r="9" fill="#e67e22"/>`);
+        s += `<line x1="${vx}" y1="${vys[i]}" x2="${hx}" y2="${hys[j]}" stroke="${COL.line}" stroke-width="0.6" opacity="0.7"/>`;
+      vys.forEach(y => s += `<circle cx="${vx}" cy="${y}" r="7" fill="${COL.accent}"/>`);
+      hys.forEach(y => s += `<circle cx="${hx}" cy="${y}" r="9" fill="${COL.warn}"/>`);
       s += `<text x="${vx}" y="12" font-size="12" text-anchor="middle" font-weight="700">visible (data)</text>`;
       s += `<text x="${hx}" y="22" font-size="12" text-anchor="middle" font-weight="700">hidden (features)</text>`;
       s += `<text x="${vx}" y="${H_-2}" font-size="10" text-anchor="middle" opacity="0.7">9 units</text>`;
       s += `<text x="${hx}" y="${H_-2}" font-size="10" text-anchor="middle" opacity="0.7">4 units · no in-layer links</text>`;
       svg.innerHTML = s;
-    })();
+    }
+    drawArch();
 
     drawErr(); drawFields(); paintVis(); clearHidden();
+    onTheme(() => { drawErr(); drawFields(); drawArch(); });
   })();
 })();
 </script>
+
+</div>

--- a/docs/_posts/2026-06-16-shannon-entropy-visually.html
+++ b/docs/_posts/2026-06-16-shannon-entropy-visually.html
@@ -6,124 +6,31 @@ categories: [Information Theory, Interactive]
 excerpt: "Entropy gets introduced as a formula — −Σ p log p — and the intuition evaporates on contact. This is the refresher I wish I'd had: entropy is just average surprise, measured in yes/no questions. Drag a coin's bias, reshape a distribution, and watch a sampler's running surprise converge onto the entropy, live in your browser."
 ---
 
+{% include study-note-styles.html %}
+
+<div class="study-note">
+
 <style>
-/* ===== layout ===== */
-.se-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border-radius: 12px;
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
-}
-.dark-theme .se-section { background: #1e1e2e; border-color: #313244; }
-.se-section h3 { margin-top: 0; color: #8e44ad; }
-.dark-theme .se-section h3 { color: #c8a2e8; }
+/* Note-specific layout. Shared components (sections, buttons, sliders,
+   tags, equations, notes, charts, numerals) live in study-note-styles.html. */
 .se-section h4 { margin-bottom: 0.5rem; }
 
-.se-equation {
-  padding: 1rem 1.5rem;
-  background: #fff;
-  border-radius: 8px;
-  border: 1px solid #dee2e6;
-  font-size: 1.1rem;
-  text-align: center;
-  margin: 1rem 0;
-  overflow-x: auto;
-}
-.dark-theme .se-equation { background: #14141e; border-color: #313244; }
-.se-equation .big { font-size: 1.25rem; }
-
-.se-note {
-  background: #f3e9fb;
-  border-radius: 8px;
-  padding: 0.9rem 1.1rem;
-  border-left: 4px solid #8e44ad;
-  font-size: 0.9rem;
-  margin: 1rem 0;
-}
-.dark-theme .se-note { background: #251a30; border-left-color: #c8a2e8; }
-
-.se-example {
-  background: #fff8e1;
-  border-radius: 8px;
-  padding: 1rem;
-  border: 1px solid #ffe082;
-  font-size: 0.9rem;
-  margin: 1rem 0;
-}
-.dark-theme .se-example { background: #2a2500; border-color: #554400; }
-
-/* ===== controls ===== */
 .se-controls { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
-.se-btn {
-  padding: 0.5rem 1.1rem;
-  border-radius: 8px;
-  border: none;
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s;
-  background: #8e44ad;
-  color: white;
-  font-family: inherit;
-}
-.se-btn.sec { background: #5d6d7e; }
-.se-btn:hover:not(:disabled) { filter: brightness(0.9); }
-.se-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.se-reset {
-  background: none;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  padding: 0.4rem 0.85rem;
-  font-size: 0.85rem;
-  cursor: pointer;
-  font-family: inherit;
-  transition: background 0.15s;
-}
-.se-reset:hover { background: #eee; }
-.dark-theme .se-reset { border-color: #444; color: #ccc; }
-.dark-theme .se-reset:hover { background: #252535; }
-
-.se-slider { -webkit-appearance: none; appearance: none; height: 6px; border-radius: 3px;
-  background: linear-gradient(90deg,#3498db,#8e44ad,#e74c3c); outline: none; cursor: pointer; }
-.se-slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 18px; height: 18px;
-  border-radius: 50%; background: #fff; border: 2px solid #8e44ad; cursor: pointer; }
-.se-slider::-moz-range-thumb { width: 18px; height: 18px; border-radius: 50%; background: #fff;
-  border: 2px solid #8e44ad; cursor: pointer; }
-.se-readout { font-weight: 700; font-size: 1.05rem; min-width: 4.5rem; display: inline-block; }
+.se-readout { font-size: 1.05rem; min-width: 4.5rem; display: inline-block; }
 
 .se-flexwrap { display: flex; gap: 1.25rem; flex-wrap: wrap; align-items: flex-start; }
 .se-panel { flex: 1; min-width: 240px; }
 
 .se-stat { text-align: center; }
 .se-stat .lab { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; }
-.se-stat .val { font-size: 1.7rem; font-weight: 700; color: #8e44ad; line-height: 1.1; }
-.dark-theme .se-stat .val { color: #c8a2e8; }
+.se-stat .val { font-size: 1.7rem; }
 .se-statrow { display: flex; gap: 2rem; justify-content: center; margin: 0.5rem 0; }
-
-.se-tag {
-  display: inline-block; padding: 0.2rem 0.6rem; border-radius: 999px;
-  font-size: 0.8rem; font-weight: 600;
-}
-.se-tag.good { background: #d5f5e3; color: #1e8449; }
-.se-tag.warn { background: #fdebd0; color: #b9770e; }
-.se-tag.hot  { background: #fadbd8; color: #c0392b; }
-.dark-theme .se-tag.good { background: #14331f; color: #6fcf97; }
-.dark-theme .se-tag.warn { background: #3a2c10; color: #f0b24a; }
-.dark-theme .se-tag.hot  { background: #3a1714; color: #f1948a; }
-
-svg text { fill: #555; }
-.dark-theme svg text { fill: #bbb; }
-
-.se-chartwrap { background: #fff; border: 1px solid #e6e6ee; border-radius: 8px; padding: 0.4rem; }
-.dark-theme .se-chartwrap { background: #11111a; border-color: #2a2a3e; }
 
 .se-legend { font-size: 0.78rem; opacity: 0.75; display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 0.4rem; }
 .se-legend span::before { content: "■ "; }
 
 /* surprise meter */
-.se-meter { background: #e8e8ef; border-radius: 8px; height: 26px; overflow: hidden; position: relative; }
-.dark-theme .se-meter { background: #1d1d2c; }
+.se-meter { background: var(--sn-panel-inset); border: 1px solid var(--sn-border); border-radius: 8px; height: 26px; overflow: hidden; position: relative; }
 .se-meter > div { height: 100%; border-radius: 8px; transition: width 0.12s ease, background 0.12s ease; }
 
 /* distribution sliders */
@@ -185,7 +92,7 @@ svg text { fill: #555; }
       <div class="se-statrow">
         <div class="se-stat"><div class="lab">surprise</div><div class="val" id="se1-bits">3.00</div><div class="lab" style="opacity:0.4">bits</div></div>
       </div>
-      <div class="se-meter" style="margin:0.6rem 0"><div id="se1-meter" style="width:30%;background:#8e44ad"></div></div>
+      <div class="se-meter" style="margin:0.6rem 0"><div id="se1-meter" style="width:30%;background:var(--sn-accent)"></div></div>
       <div id="se1-msg" style="font-size:0.85rem;opacity:0.85;text-align:center;min-height:3.2em"></div>
     </div>
   </div>
@@ -280,7 +187,7 @@ svg text { fill: #555; }
       </div>
       <div class="se-statrow" style="margin-top:0.6rem">
         <div class="se-stat"><div class="lab">entropy H</div><div class="val" id="se3-h">—</div><div class="lab" style="opacity:0.4">bits</div></div>
-        <div class="se-stat"><div class="lab">max (log<sub>2</sub>N)</div><div class="val" id="se3-max" style="color:#5d6d7e">—</div><div class="lab" style="opacity:0.4">bits</div></div>
+        <div class="se-stat"><div class="lab">max (log<sub>2</sub>N)</div><div class="val" id="se3-max" style="color:var(--sn-muted)">—</div><div class="lab" style="opacity:0.4">bits</div></div>
       </div>
       <div style="text-align:center"><span id="se3-tag" class="se-tag warn">—</span></div>
     </div>
@@ -320,14 +227,14 @@ svg text { fill: #555; }
     <svg id="se4-svg" width="100%" height="200" viewBox="0 0 720 200" preserveAspectRatio="none" style="display:block"></svg>
   </div>
   <div class="se-legend">
-    <span style="color:#8e44ad">running average surprise</span>
-    <span style="color:#27ae60">entropy H (target)</span>
+    <span style="color:var(--sn-accent)">running average surprise</span>
+    <span style="color:var(--sn-good)">entropy H (target)</span>
   </div>
 
   <div class="se-statrow" style="margin-top:0.6rem">
     <div class="se-stat"><div class="lab">draws</div><div class="val" id="se4-n">0</div></div>
     <div class="se-stat"><div class="lab">avg surprise</div><div class="val" id="se4-avg">—</div></div>
-    <div class="se-stat"><div class="lab">entropy H</div><div class="val" id="se4-h" style="color:#27ae60">—</div></div>
+    <div class="se-stat"><div class="lab">entropy H</div><div class="val" id="se4-h" style="color:var(--sn-good)">—</div></div>
   </div>
   <div class="se-note" style="margin-bottom:0">
     <strong>Try this:</strong> shape a lopsided distribution above, then run the sampler — the average
@@ -357,6 +264,20 @@ svg text { fill: #555; }
 <script>
 (function () {
   "use strict";
+  // theme-aware colors: read CSS tokens, re-read + redraw on light/dark toggle
+  const SN = document.querySelector(".study-note");
+  const readCols = () => {
+    const cs = getComputedStyle(SN);
+    const c = n => cs.getPropertyValue(n).trim();
+    return { accent: c("--sn-accent"), good: c("--sn-good"), bad: c("--sn-bad"),
+             muted: c("--sn-muted"), grid: c("--sn-grid") };
+  };
+  let COL = readCols();
+  const redrawFns = [];
+  const onTheme = fn => { redrawFns.push(fn); return fn; };
+  new MutationObserver(() => { COL = readCols(); redrawFns.forEach(f => f()); })
+    .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+
   const log2 = x => Math.log(x) / Math.LN2;
   const clamp = (x, a, b) => Math.max(a, Math.min(b, x));
   // surprise of an event, guarded against p<=0
@@ -389,7 +310,7 @@ svg text { fill: #555; }
       pval.textContent = p.toFixed(3);
       bitsEl.textContent = h.toFixed(2);
       meter.style.width = clamp(h / hMax * 100, 2, 100).toFixed(1) + "%";
-      meter.style.background = h < 1 ? "#27ae60" : h < 3 ? "#8e44ad" : "#e74c3c";
+      meter.style.background = h < 1 ? COL.good : h < 3 ? COL.accent : COL.bad;
 
       // curve h = -log2 p
       let path = "";
@@ -401,20 +322,20 @@ svg text { fill: #555; }
       let grid = "";
       [0, 1, 2, 3, 4, 5].forEach(b => {
         if (b > hMax) return;
-        grid += `<line x1="${padL}" y1="${Y(b)}" x2="${W - padR}" y2="${Y(b)}" stroke="#eee" stroke-width="1"/>`;
+        grid += `<line x1="${padL}" y1="${Y(b)}" x2="${W - padR}" y2="${Y(b)}" stroke="${COL.grid}" stroke-width="1"/>`;
         grid += `<text x="${padL - 6}" y="${Y(b) + 3}" font-size="10" text-anchor="end">${b}</text>`;
       });
       [0, 0.25, 0.5, 0.75, 1].forEach(px => {
-        grid += `<line x1="${X(px)}" y1="${padT}" x2="${X(px)}" y2="${H - padB}" stroke="#f1f1f1" stroke-width="1"/>`;
+        grid += `<line x1="${X(px)}" y1="${padT}" x2="${X(px)}" y2="${H - padB}" stroke="${COL.grid}" stroke-width="1"/>`;
         grid += `<text x="${X(px)}" y="${H - padB + 16}" font-size="10" text-anchor="middle">${px}</text>`;
       });
       const marker =
-        `<line x1="${X(p)}" y1="${Y(h)}" x2="${X(p)}" y2="${H - padB}" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="3 3"/>` +
-        `<circle cx="${X(p)}" cy="${Y(h)}" r="6" fill="#e74c3c"/>` +
-        `<text x="${clamp(X(p) + 9, padL, W - padR - 60)}" y="${clamp(Y(h) - 6, padT + 12, H - padB)}" font-size="12" fill="#e74c3c" font-weight="700">${h.toFixed(2)} bits</text>`;
+        `<line x1="${X(p)}" y1="${Y(h)}" x2="${X(p)}" y2="${H - padB}" stroke="${COL.bad}" stroke-width="1.5" stroke-dasharray="3 3"/>` +
+        `<circle cx="${X(p)}" cy="${Y(h)}" r="6" fill="${COL.bad}"/>` +
+        `<text x="${clamp(X(p) + 9, padL, W - padR - 60)}" y="${clamp(Y(h) - 6, padT + 12, H - padB)}" font-size="12" fill="${COL.bad}" font-weight="700">${h.toFixed(2)} bits</text>`;
       svg.innerHTML =
         grid +
-        `<path d="${path}" fill="none" stroke="#8e44ad" stroke-width="2.5"/>` +
+        `<path d="${path}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>` +
         marker +
         `<text x="${X(0.5)}" y="${H - 4}" font-size="11" text-anchor="middle">probability of the outcome  p(x)</text>` +
         `<text x="13" y="${padT + 84}" font-size="11" transform="rotate(-90 13 ${padT + 84})" text-anchor="middle">surprise (bits)</text>`;
@@ -425,6 +346,7 @@ svg text { fill: #555; }
       else msg.innerHTML = "Halve the probability and the surprise goes up by exactly one bit.";
     }
     pSlider.addEventListener("input", draw);
+    onTheme(draw);
     draw();
   })();
 
@@ -459,21 +381,21 @@ svg text { fill: #555; }
       }
       let grid = "";
       [0, 0.25, 0.5, 0.75, 1].forEach(b => {
-        grid += `<line x1="${padL}" y1="${Y(b)}" x2="${W - padR}" y2="${Y(b)}" stroke="#eee" stroke-width="1"/>`;
+        grid += `<line x1="${padL}" y1="${Y(b)}" x2="${W - padR}" y2="${Y(b)}" stroke="${COL.grid}" stroke-width="1"/>`;
         grid += `<text x="${padL - 6}" y="${Y(b) + 3}" font-size="10" text-anchor="end">${b.toFixed(2)}</text>`;
       });
       [0, 0.25, 0.5, 0.75, 1].forEach(px => {
-        grid += `<line x1="${X(px)}" y1="${padT}" x2="${X(px)}" y2="${H - padB}" stroke="#f1f1f1" stroke-width="1"/>`;
+        grid += `<line x1="${X(px)}" y1="${padT}" x2="${X(px)}" y2="${H - padB}" stroke="${COL.grid}" stroke-width="1"/>`;
         grid += `<text x="${X(px)}" y="${H - padB + 16}" font-size="10" text-anchor="middle">${px}</text>`;
       });
       const peak = `<line x1="${X(0.5)}" y1="${Y(1)}" x2="${X(0.5)}" y2="${H - padB}" stroke="#bbb" stroke-dasharray="4 4"/>` +
         `<text x="${X(0.5)}" y="${Y(1) - 4}" font-size="10" text-anchor="middle" opacity="0.7">1 bit max</text>`;
       const marker =
-        `<line x1="${X(p)}" y1="${Y(h)}" x2="${X(p)}" y2="${H - padB}" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="3 3"/>` +
-        `<circle cx="${X(p)}" cy="${Y(h)}" r="6" fill="#e74c3c"/>`;
+        `<line x1="${X(p)}" y1="${Y(h)}" x2="${X(p)}" y2="${H - padB}" stroke="${COL.bad}" stroke-width="1.5" stroke-dasharray="3 3"/>` +
+        `<circle cx="${X(p)}" cy="${Y(h)}" r="6" fill="${COL.bad}"/>`;
       svg.innerHTML =
         grid + peak +
-        `<path d="${path}" fill="none" stroke="#8e44ad" stroke-width="2.5"/>` +
+        `<path d="${path}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>` +
         marker +
         `<text x="${X(0.5)}" y="${H - 4}" font-size="11" text-anchor="middle">p(heads)</text>` +
         `<text x="13" y="${padT + 92}" font-size="11" transform="rotate(-90 13 ${padT + 92})" text-anchor="middle">entropy H (bits)</text>`;
@@ -487,6 +409,7 @@ svg text { fill: #555; }
       else msg.innerHTML = "Bias the coin and entropy falls: outcomes are easier to guess, so each carries fewer bits on average.";
     }
     pSlider.addEventListener("input", draw);
+    onTheme(draw);
     draw();
   })();
 
@@ -495,7 +418,7 @@ svg text { fill: #555; }
   // ============================================================
   const dist = {
     names: ["☀️ Sunny", "⛅ Cloudy", "🌧️ Rain", "⛈️ Storm", "❄️ Snow"],
-    colors: ["#f39c12", "#7f8c8d", "#2980b9", "#8e44ad", "#16a3c9"],
+    colors: ["#0891b2", "#0ea5b8", "#22b8c9", "#67cdd9", "#a5e3ea"],
     raw: [5, 3, 2, 1, 0.6],   // unnormalised slider weights
     probs() { const s = this.raw.reduce((a, b) => a + b, 0); return this.raw.map(w => w / s); },
     listeners: [],
@@ -551,7 +474,7 @@ svg text { fill: #555; }
       let out = "";
       [0.25, 0.5, 0.75, 1].forEach(f => {
         const y = H - padB - f * top;
-        out += `<line x1="${padL}" y1="${y}" x2="${W}" y2="${y}" stroke="#eee" stroke-width="1"/>`;
+        out += `<line x1="${padL}" y1="${y}" x2="${W}" y2="${y}" stroke="${COL.grid}" stroke-width="1"/>`;
       });
       probs.forEach((p, i) => {
         const x = padL + i * slot + (slot - barW) / 2;
@@ -578,6 +501,7 @@ svg text { fill: #555; }
     });
 
     dist.listeners.push(draw);
+    onTheme(draw);
     draw();
   })();
 
@@ -633,18 +557,18 @@ svg text { fill: #555; }
       let grid = "";
       const ticks = [0, 0.5, 1, 1.5, 2, 2.5].filter(t => t <= yMax);
       ticks.forEach(t => {
-        grid += `<line x1="${padL}" y1="${Y(t)}" x2="${W - padR}" y2="${Y(t)}" stroke="#f0f0f0" stroke-width="1"/>`;
+        grid += `<line x1="${padL}" y1="${Y(t)}" x2="${W - padR}" y2="${Y(t)}" stroke="${COL.grid}" stroke-width="1"/>`;
         grid += `<text x="${padL - 6}" y="${Y(t) + 3}" font-size="9" text-anchor="end">${t}</text>`;
       });
       // target entropy line
       const targetLine =
-        `<line x1="${padL}" y1="${Y(Htarget)}" x2="${W - padR}" y2="${Y(Htarget)}" stroke="#27ae60" stroke-width="2" stroke-dasharray="6 4"/>` +
-        `<text x="${W - padR}" y="${Y(Htarget) - 5}" font-size="10" text-anchor="end" fill="#27ae60">H = ${Htarget.toFixed(2)}</text>`;
+        `<line x1="${padL}" y1="${Y(Htarget)}" x2="${W - padR}" y2="${Y(Htarget)}" stroke="${COL.good}" stroke-width="2" stroke-dasharray="6 4"/>` +
+        `<text x="${W - padR}" y="${Y(Htarget) - 5}" font-size="10" text-anchor="end" fill="${COL.good}">H = ${Htarget.toFixed(2)}</text>`;
       // running-average path
       let d = "";
       hist.forEach((v, k) => { d += (k === 0 ? "M" : "L") + X(k).toFixed(1) + " " + Y(v).toFixed(1) + " "; });
-      const trace = hist.length ? `<path d="${d}" fill="none" stroke="#8e44ad" stroke-width="2"/>` : "";
-      const dot = hist.length ? `<circle cx="${X(hist.length - 1).toFixed(1)}" cy="${Y(hist[hist.length - 1]).toFixed(1)}" r="3.5" fill="#8e44ad"/>` : "";
+      const trace = hist.length ? `<path d="${d}" fill="none" stroke="${COL.accent}" stroke-width="2"/>` : "";
+      const dot = hist.length ? `<circle cx="${X(hist.length - 1).toFixed(1)}" cy="${Y(hist[hist.length - 1]).toFixed(1)}" r="3.5" fill="${COL.accent}"/>` : "";
       svg.innerHTML = grid + targetLine + trace + dot +
         `<text x="${padL}" y="${H - 4}" font-size="9" opacity="0.6">draws →</text>`;
     }
@@ -667,7 +591,10 @@ svg text { fill: #555; }
 
     // when the distribution changes, the target line moves; redraw (keeps history for contrast)
     dist.listeners.push(draw);
+    onTheme(draw);
     draw();
   })();
 })();
 </script>
+
+</div>

--- a/docs/_posts/CLAUDE.md
+++ b/docs/_posts/CLAUDE.md
@@ -1,0 +1,114 @@
+# Study Notes — authoring guide
+
+Interactive study notes live here as standalone HTML posts (`layout: post`) with an
+inline `<style>` block and embedded vanilla JS. They share one **sleek / futuristic**
+design system so they look cohesive and never drift back toward the old "gamey,
+blue-and-violet" look. Follow these rules when creating or editing a note.
+
+## Required scaffold
+
+Right under the front matter, pull in the shared styles and wrap the whole body in
+`.study-note`:
+
+```liquid
+---
+layout: post
+title: "..."
+date: YYYY-MM-DD
+categories: [Topic, Interactive]
+excerpt: "..."
+---
+
+{% include study-note-styles.html %}
+
+<div class="study-note">
+
+<style>
+/* note-specific LAYOUT only — colors come from tokens, shared components
+   come from study-note-styles.html */
+</style>
+
+... content, demos ...
+
+<script> ... </script>
+
+</div>
+```
+
+The wrapper matters: `study-note-styles.html` scopes everything (including
+`svg text`) under `.study-note`, and the dark-mode token overrides key off
+`.dark-theme .study-note`. Without the wrapper, nothing themes correctly.
+
+## Use the design tokens — never hardcode brand colors
+
+Defined in `_includes/study-note-styles.html` on `.study-note`, with
+`.dark-theme .study-note` overrides (so light + dark both work for free):
+
+| Token | Use |
+| --- | --- |
+| `--sn-accent` / `--sn-accent-strong` | primary accent (cyan-teal); links, active states, curves |
+| `--sn-accent-soft` / `--sn-accent-line` | tinted fills / hairline accent borders |
+| `--sn-on-accent` | text/icon color on top of an accent fill |
+| `--sn-panel` / `--sn-panel-inset` / `--sn-section` | surfaces (card, inset, section bg) |
+| `--sn-border` / `--sn-grid` | hairline borders / SVG gridlines |
+| `--sn-text` / `--sn-muted` | body / secondary text |
+| `--sn-good` `--sn-warn` `--sn-bad` (+ `*-bg`) | semantic status only, desaturated |
+| `--sn-radius` / `--sn-radius-sm` | corner radii |
+| `--sn-shadow` / `--sn-glow` / `--sn-ease` | depth / dark-only glow / easing |
+| `--sn-mono` | numerals, readouts, code |
+
+**Never** use purple (`#8e44ad`), the old blue (`#2980b9`/`#4a90e2`), or rainbow
+gradients. Accent reference: `#0891b2` (light) / `#22d3ee` (dark) / `#06b6d4` (mid).
+
+## Component rules
+
+- **Sliders** are flat and single-accent (neutral track + accent thumb with a soft
+  ring). No multi-color gradient tracks. Just give a range input class `se-slider`/
+  `bm-slider`, or rely on `.study-note input[type="range"]`.
+- **Status tags** are desaturated pills (`se-tag`/`bm-tag` + `.good`/`.warn`/`.hot`):
+  soft token background + token text, no hard borders.
+- **Cards / boxes** use a 1px `--sn-border` (or accent-line) and `--sn-radius`, not
+  bold 2-4px borders. Reuse `se-section`/`bm-section`/`mdp-section`, `se-equation`,
+  `se-note`, `se-example`, `se-chartwrap`/`graph-wrap`.
+- **Buttons**: primary = `se-btn`/`bm-btn`/`vi-btn` (solid accent, lift + glow on
+  hover); secondary = add `.sec`; quiet = `se-reset`/`bm-reset`/`reset-link`.
+- **Numerals** (stats, readouts, scores) use `--sn-mono` + `tabular-nums` + accent.
+- **Motion** uses `--sn-ease`; the glow (`--sn-glow`) is dark-mode-only by design —
+  apply it via `box-shadow: var(--sn-glow)` and it stays `none` in light mode.
+
+## Adaptive charts (JS-drawn SVG/canvas)
+
+Hardcoded hex in JS does not react to the theme toggle. Read tokens at runtime and
+redraw on toggle. Pattern used across the notes:
+
+```js
+const SN = document.querySelector(".study-note");
+const readCols = () => { const cs = getComputedStyle(SN); const c = n => cs.getPropertyValue(n).trim();
+  return { accent: c("--sn-accent"), good: c("--sn-good"), bad: c("--sn-bad"),
+           warn: c("--sn-warn"), muted: c("--sn-muted"), grid: c("--sn-grid") }; };
+let COL = readCols();
+const redrawFns = [];
+const onTheme = fn => { redrawFns.push(fn); return fn; };
+new MutationObserver(() => { COL = readCols(); redrawFns.forEach(f => f()); })
+  .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+// ...then in each demo: use COL.accent/COL.grid/... and call onTheme(draw);
+```
+
+For interpolated colors (e.g. energy/weight ramps) blend between tokens with a small
+`hex2rgb`/`mix` helper (see the Boltzmann note) instead of literal blue→red ramps.
+
+## Don't break interactivity
+
+The JS keys off specific ids and class names (e.g. `se-tag.good`, `bm-cell.on`,
+`bm-cell.flash`, `state-badge.active`, `action-btn[data-action]`, `vi-table td.best`,
+`log-entry`/`popin`). Restyle freely, but **do not rename** a selector the JS reads or
+toggles, and keep the `data-action` / state class hooks intact.
+
+## Preview
+
+```sh
+cd docs && bundle exec jekyll serve --livereload   # http://localhost:4000/
+```
+
+Check each demo in **both** light and dark (toggle bottom-right). Sliders, buttons,
+tags, charts, and the theme toggle should all stay cyan/sleek with no purple.


### PR DESCRIPTION
The three interactive study notes each shipped their own inline styles with
clashing palettes (purple #8e44ad in two, blue #2980b9 in the MDP note),
multi-color gradient sliders, bright saturated status chips, and bold-bordered
gray boxes — reading more "gamey" than sleek.

Introduce one shared, cyan/teal design system that adapts to both the light and
dark site themes:

- New _includes/study-note-styles.html holds design tokens (--sn-*) plus the
  shared sleek components (flat single-accent sliders, desaturated pill tags,
  hairline cards, accent buttons with dark-only glow, monospace numerals). Every
  selector is scoped under .study-note, replacing the old leaky global svg rule.
- Each note now includes the shared styles, wraps its body in .study-note, and
  its inline styles are reduced to layout that consumes the tokens.
- JS-drawn chart colors are read from the CSS tokens at runtime and redraw on
  theme toggle via a MutationObserver, so charts stay legible and on-theme in
  both light and dark. All JS-referenced ids/classes are preserved.
- Add _posts/CLAUDE.md documenting the design system so future notes stay on-style.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BWS4p3L6qCgWmiwszv1vQW