### PR TITLE
Add interactive options theory study note

### DIFF
--- a/docs/_posts/2026-06-19-options-theory-visually.html
+++ b/docs/_posts/2026-06-19-options-theory-visually.html
@@ -1,0 +1,821 @@
+---
+layout: post
+title: "Options Theory, Visually: Payoffs, Black–Scholes, and the Greeks"
+date: 2026-06-19
+categories: [Finance, Interactive]
+excerpt: "An option price looks like an act of faith — N(d₁), N(d₂), a formula nobody re-derives twice. This is the refresher I wish I'd had: an option's price is just the discounted, risk-neutral expectation of its payoff, and volatility is the whole game. Drag the strike, widen the volatility, watch a Monte-Carlo average crawl onto the Black–Scholes price, and feel the Greeks move as slopes and curvature — live in your browser."
+---
+
+{% include study-note-styles.html %}
+
+<div class="study-note">
+
+<style>
+/* Note-specific layout only. Colors come from tokens; styled components
+   (se-section, se-equation, se-note, se-example, se-chartwrap, se-btn,
+   se-tag, se-stat, se-readout) come from study-note-styles.html. */
+.ot-controls { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin: 0.7rem 0; }
+.ot-controls .nm { font-size: 0.85rem; min-width: 3.2rem; }
+.ot-readout { font-size: 1.0rem; min-width: 3.4rem; display: inline-block; text-align: right; }
+
+.ot-flexwrap { display: flex; gap: 1.25rem; flex-wrap: wrap; align-items: flex-start; }
+.ot-panel { flex: 1; min-width: 250px; }
+
+.ot-stat { text-align: center; }
+.ot-stat .lab { font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; }
+.ot-stat .val { font-family: var(--sn-mono); font-variant-numeric: tabular-nums; color: var(--sn-accent); font-weight: 700; font-size: 1.5rem; line-height: 1.15; }
+.ot-stat .val.good { color: var(--sn-good); }
+.ot-stat .val.bad  { color: var(--sn-bad); }
+.ot-statrow { display: flex; gap: 1.4rem; justify-content: center; flex-wrap: wrap; margin: 0.6rem 0; }
+
+.ot-toggle { display: flex; gap: 0.4rem; flex-wrap: wrap; margin: 0.2rem 0 0.6rem; }
+.ot-legend { font-size: 0.76rem; opacity: 0.78; display: flex; gap: 1.1rem; flex-wrap: wrap; margin-top: 0.45rem; }
+.ot-legend span::before { content: "■ "; }
+
+.ot-msg { font-size: 0.85rem; opacity: 0.88; text-align: center; min-height: 2.6em; margin-top: 0.4rem; }
+</style>
+
+<p>
+  When I first met the <strong>Black–Scholes formula</strong> it arrived the way it usually does —
+  <em>C = S·N(d₁) − K e<sup>−rT</sup>·N(d₂)</em>, scrawled on a board, with a promise that the two
+  cumulative normals "fall out of the math." I memorised it, passed the exam, and could not have told
+  you a week later <em>why</em> there were two of them. This post is the refresher I wish I'd had:
+  every piece attached to something you can drag, widen, and run.
+</p>
+
+<p>Here's the whole story in one sentence, and everything below just unpacks it:</p>
+
+<div class="se-note">
+  <strong>An option's price is the discounted, risk-neutral expectation of its payoff.</strong>
+  You hold the <em>right, not the obligation</em>, to trade at a fixed price, so your payoff is bent —
+  all upside, capped downside. Because the payoff is convex, <strong>volatility creates value</strong>;
+  and because a dynamic hedge can replicate the option, no-arbitrage pins the price to a single number.
+  Black–Scholes is just that expectation, written in closed form.
+</div>
+
+<!-- ============================================================ -->
+<!-- 1. PAYOFF & P/L                                              -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>📈 The bent payoff: calls, puts, and P/L</h3>
+  <p style="margin-top:0">
+    Owning the stock is a straight line: gain a dollar when it rises, lose one when it falls. An option
+    <em>bends</em> that line at the <strong>strike</strong> K. A <strong>call</strong> is the right to
+    <em>buy</em> at K; a <strong>put</strong> is the right to <em>sell</em> at K. At expiry only the
+    intrinsic value survives:
+  </p>
+  <div class="se-equation">
+    <span class="big">Call payoff = max(S<sub>T</sub> &minus; K, 0)</span> &nbsp;&nbsp;&middot;&nbsp;&nbsp;
+    <span class="big">Put payoff = max(K &minus; S<sub>T</sub>, 0)</span>
+  </div>
+  <p style="margin-top:0">
+    You pay a <strong>premium</strong> up front, so your <em>profit &amp; loss</em> is the payoff minus
+    what you paid (and flipped if you're the seller). Toggle the contract, drag the strike, the premium,
+    and the spot — the solid line is payoff at expiry, the dashed line is your P/L:
+  </p>
+
+  <div class="ot-toggle">
+    <button class="se-btn" id="ot1-call">Call</button>
+    <button class="se-btn sec" id="ot1-put">Put</button>
+    <span style="width:0.6rem"></span>
+    <button class="se-btn" id="ot1-long">Long (buy)</button>
+    <button class="se-btn sec" id="ot1-short">Short (sell)</button>
+  </div>
+
+  <div class="ot-flexwrap">
+    <div class="ot-panel" style="flex:2">
+      <div class="se-chartwrap"><svg id="ot1-svg" width="100%" height="260" viewBox="0 0 480 260"></svg></div>
+      <div class="ot-legend">
+        <span style="color:var(--sn-accent)">payoff at expiry</span>
+        <span style="color:var(--sn-good)">profit / loss</span>
+        <span style="color:var(--sn-bad)">strike K</span>
+      </div>
+    </div>
+    <div class="ot-panel">
+      <div class="ot-controls"><span class="nm">spot S</span><input type="range" id="ot1-s" min="0" max="200" value="105" style="flex:1"><span class="ot-readout" id="ot1-sv">105</span></div>
+      <div class="ot-controls"><span class="nm">strike K</span><input type="range" id="ot1-k" min="20" max="180" value="100" style="flex:1"><span class="ot-readout" id="ot1-kv">100</span></div>
+      <div class="ot-controls"><span class="nm">premium</span><input type="range" id="ot1-prem" min="0" max="400" value="80" style="flex:1"><span class="ot-readout" id="ot1-pv">8.0</span></div>
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">moneyness</div><div class="val" id="ot1-money" style="font-size:1.1rem">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">breakeven</div><div class="val" id="ot1-be">&mdash;</div></div>
+      </div>
+      <div class="ot-msg" id="ot1-msg"></div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 2. INTRINSIC vs TIME VALUE                                   -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>⏳ Before expiry: intrinsic value plus time value</h3>
+  <p style="margin-top:0">
+    Before maturity an option is worth <em>more</em> than its intrinsic payoff, because the future is
+    still uncertain — there's time for the bet to come good. The live price is a smooth curve sitting
+    <strong>above</strong> the kinked payoff, and the gap is the <strong>time value</strong>:
+  </p>
+  <div class="se-equation"><span class="big">price = intrinsic value + time value</span></div>
+  <p style="margin-top:0">
+    Drag time-to-expiry T toward zero and watch the curve melt down onto the hockey stick — the time
+    value bleeds away. That decay is <strong>theta</strong>, and it accelerates near expiry:
+  </p>
+
+  <div class="ot-flexwrap">
+    <div class="ot-panel" style="flex:2">
+      <div class="se-chartwrap"><svg id="ot2-svg" width="100%" height="260" viewBox="0 0 480 260"></svg></div>
+      <div class="ot-legend">
+        <span style="color:var(--sn-accent)">option price (T &gt; 0)</span>
+        <span style="color:var(--sn-muted)">payoff at expiry</span>
+        <span style="color:var(--sn-warn)">time value gap</span>
+      </div>
+    </div>
+    <div class="ot-panel">
+      <div class="ot-controls"><span class="nm">T (yrs)</span><input type="range" id="ot2-t" min="1" max="200" value="100" style="flex:1"><span class="ot-readout" id="ot2-tv">1.00</span></div>
+      <div class="ot-controls"><span class="nm">vol &sigma;</span><input type="range" id="ot2-vol" min="5" max="80" value="25" style="flex:1"><span class="ot-readout" id="ot2-volv">0.25</span></div>
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">price (ATM)</div><div class="val" id="ot2-price">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">time value</div><div class="val" id="ot2-tval">&mdash;</div></div>
+      </div>
+      <div class="ot-msg" id="ot2-msg">K = 100, r = 2%. A call.</div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 3. VOLATILITY — THE KEYSTONE                                 -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🌪️ Volatility is the whole game</h3>
+  <p style="margin-top:0">
+    Here is the engine room. Under the <strong>risk-neutral</strong> measure the stock drifts at the
+    risk-free rate and its terminal price is <strong>log-normal</strong>. The option is worth the
+    discounted average payoff over that distribution:
+  </p>
+  <div class="se-equation">
+    <span class="big">V = e<sup>&minus;rT</sup> &middot; E<sub>Q</sub>[ payoff(S<sub>T</sub>) ]</span>,
+    &nbsp; with &nbsp; S<sub>T</sub> = S<sub>0</sub> e<sup>(r &minus; &sigma;&sup2;/2)T + &sigma;&radic;T &middot; Z</sup>, &nbsp; Z ~ 𝒩(0,1)
+  </div>
+  <p style="margin-top:0">
+    Now the punchline. The payoff is <strong>convex</strong> — clipped at zero on the downside, open on
+    the upside — so spreading the distribution wider <em>adds</em> expected payoff (big gains aren't
+    cancelled by big losses, because the losses are capped). Drag <strong>&sigma;</strong>: the bell
+    fattens, the shaded expected-payoff mass grows, and the price climbs. The readout computes
+    e<sup>&minus;rT</sup>E[payoff] numerically — and it lands on the Black–Scholes price below.
+  </p>
+
+  <div class="ot-flexwrap">
+    <div class="ot-panel" style="flex:2">
+      <div class="se-chartwrap"><svg id="ot3-svg" width="100%" height="260" viewBox="0 0 480 260"></svg></div>
+      <div class="ot-legend">
+        <span style="color:var(--sn-accent)">density of S<sub>T</sub></span>
+        <span style="color:var(--sn-good)">payoff × density (value)</span>
+        <span style="color:var(--sn-bad)">strike K</span>
+      </div>
+    </div>
+    <div class="ot-panel">
+      <div class="ot-controls"><span class="nm">vol &sigma;</span><input type="range" id="ot3-vol" min="3" max="90" value="25" style="flex:1"><span class="ot-readout" id="ot3-volv">0.25</span></div>
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">E[payoff]·e<sup>&minus;rT</sup></div><div class="val" id="ot3-num">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">Black–Scholes</div><div class="val good" id="ot3-bs">&mdash;</div></div>
+      </div>
+      <div class="ot-msg" id="ot3-msg">S₀ = K = 100, r = 2%, T = 1. A call.</div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 4. BLACK–SCHOLES                                             -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🧮 Black–Scholes in closed form</h3>
+  <p style="margin-top:0">
+    Where does the formula come from? Build a portfolio of the option and &minus;&Delta; shares so the
+    random moves cancel. A hedged, riskless portfolio must earn the risk-free rate — that no-arbitrage
+    argument turns into the <strong>Black–Scholes PDE</strong>:
+  </p>
+  <div class="se-equation">
+    <span class="big">&part;V/&part;t + &frac12;&sigma;&sup2;S&sup2; &part;&sup2;V/&part;S&sup2; + rS &part;V/&part;S &minus; rV = 0</span>
+  </div>
+  <p style="margin-top:0">
+    Solve it with the terminal condition V(S, T) = payoff(S) and the discounted-expectation integral
+    collapses into two cumulative normals:
+  </p>
+  <div class="se-equation">
+    <span class="big">C = S·N(d<sub>1</sub>) &minus; K e<sup>&minus;rT</sup> N(d<sub>2</sub>)</span><br>
+    <span style="font-size:0.95rem">d<sub>1</sub> = [ ln(S/K) + (r + &sigma;&sup2;/2)T ] / (&sigma;&radic;T), &nbsp;&nbsp; d<sub>2</sub> = d<sub>1</sub> &minus; &sigma;&radic;T</span>
+  </div>
+  <p style="margin-top:0">
+    Read it as the bet itself: <strong>N(d<sub>2</sub>)</strong> is the risk-neutral probability the
+    call finishes in the money; <strong>N(d<sub>1</sub>)</strong> is that probability re-weighted by how
+    much stock you'd be holding. Drive all five inputs and watch the price and the curve respond:
+  </p>
+
+  <div class="ot-toggle">
+    <button class="se-btn" id="ot4-call">Call</button>
+    <button class="se-btn sec" id="ot4-put">Put</button>
+  </div>
+  <div class="ot-flexwrap">
+    <div class="ot-panel" style="flex:2">
+      <div class="se-chartwrap"><svg id="ot4-svg" width="100%" height="260" viewBox="0 0 480 260"></svg></div>
+      <div class="ot-legend">
+        <span style="color:var(--sn-accent)">option price vs spot</span>
+        <span style="color:var(--sn-muted)">payoff at expiry</span>
+        <span style="color:var(--sn-bad)">current spot S</span>
+      </div>
+    </div>
+    <div class="ot-panel">
+      <div class="ot-controls"><span class="nm">spot S</span><input type="range" id="ot4-s" min="20" max="180" value="100" style="flex:1"><span class="ot-readout" id="ot4-sv">100</span></div>
+      <div class="ot-controls"><span class="nm">strike K</span><input type="range" id="ot4-k" min="20" max="180" value="100" style="flex:1"><span class="ot-readout" id="ot4-kv">100</span></div>
+      <div class="ot-controls"><span class="nm">vol &sigma;</span><input type="range" id="ot4-vol" min="3" max="90" value="25" style="flex:1"><span class="ot-readout" id="ot4-volv">0.25</span></div>
+      <div class="ot-controls"><span class="nm">T (yrs)</span><input type="range" id="ot4-t" min="1" max="200" value="100" style="flex:1"><span class="ot-readout" id="ot4-tv">1.00</span></div>
+      <div class="ot-controls"><span class="nm">rate r</span><input type="range" id="ot4-r" min="0" max="120" value="20" style="flex:1"><span class="ot-readout" id="ot4-rv">0.02</span></div>
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">price</div><div class="val" id="ot4-price">&mdash;</div></div>
+      </div>
+      <div class="ot-statrow" style="gap:1.0rem;font-size:0.8rem">
+        <div class="ot-stat"><div class="lab">d₁</div><div class="val" id="ot4-d1" style="font-size:1.0rem">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">d₂</div><div class="val" id="ot4-d2" style="font-size:1.0rem">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">N(d₁)</div><div class="val" id="ot4-nd1" style="font-size:1.0rem">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">N(d₂)</div><div class="val" id="ot4-nd2" style="font-size:1.0rem">&mdash;</div></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 5. THE GREEKS                                                -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🔢 The Greeks: slopes, curvature, and decay</h3>
+  <p style="margin-top:0">
+    The Greeks are just partial derivatives of the price — its sensitivities to each input. Two of them
+    are right there in the picture: <strong>delta</strong> is the <em>slope</em> of the price curve, and
+    <strong>gamma</strong> is its <em>curvature</em>. The tangent line below is delta; how fast that
+    tangent rotates as you move spot is gamma.
+  </p>
+  <div class="se-equation">
+    <span style="font-size:0.98rem">
+      &Delta; = &part;V/&part;S = N(d<sub>1</sub>) &nbsp;&middot;&nbsp;
+      &Gamma; = &part;&sup2;V/&part;S&sup2; = N'(d<sub>1</sub>)/(S&sigma;&radic;T) &nbsp;&middot;&nbsp;
+      𝜈 = &part;V/&part;&sigma; = S·N'(d<sub>1</sub>)&radic;T
+    </span><br>
+    <span style="font-size:0.98rem">
+      &Theta; = &part;V/&part;t = &minus;S·N'(d<sub>1</sub>)&sigma;/(2&radic;T) &minus; rK e<sup>&minus;rT</sup>N(d<sub>2</sub>) &nbsp;&middot;&nbsp;
+      &rho; = &part;V/&part;r = K T e<sup>&minus;rT</sup>N(d<sub>2</sub>)
+    </span>
+  </div>
+  <p style="margin-top:0">
+    Slide spot, volatility, and time. <span class="se-tag good">Δ</span> a call's delta runs 0→1;
+    <span class="se-tag good">Γ</span> gamma peaks at the money; <span class="se-tag hot">Θ</span> theta
+    is negative (time hurts the owner); <span class="se-tag good">𝜈</span> vega is largest at the money
+    and with more time left.
+  </p>
+
+  <div class="ot-flexwrap">
+    <div class="ot-panel" style="flex:2">
+      <div class="se-chartwrap"><svg id="ot5-svg" width="100%" height="260" viewBox="0 0 480 260"></svg></div>
+      <div class="ot-legend">
+        <span style="color:var(--sn-accent)">call price vs spot</span>
+        <span style="color:var(--sn-warn)">tangent (slope = Δ)</span>
+        <span style="color:var(--sn-bad)">current spot S</span>
+      </div>
+    </div>
+    <div class="ot-panel">
+      <div class="ot-controls"><span class="nm">spot S</span><input type="range" id="ot5-s" min="40" max="160" value="100" style="flex:1"><span class="ot-readout" id="ot5-sv">100</span></div>
+      <div class="ot-controls"><span class="nm">vol &sigma;</span><input type="range" id="ot5-vol" min="5" max="90" value="25" style="flex:1"><span class="ot-readout" id="ot5-volv">0.25</span></div>
+      <div class="ot-controls"><span class="nm">T (yrs)</span><input type="range" id="ot5-t" min="2" max="200" value="100" style="flex:1"><span class="ot-readout" id="ot5-tv">1.00</span></div>
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">Δ delta</div><div class="val" id="ot5-delta">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">Γ gamma</div><div class="val" id="ot5-gamma">&mdash;</div></div>
+      </div>
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">Θ / day</div><div class="val" id="ot5-theta">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">𝜈 / 1%</div><div class="val" id="ot5-vega">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">ρ / 1%</div><div class="val" id="ot5-rho">&mdash;</div></div>
+      </div>
+      <div class="ot-msg" id="ot5-msg">K = 100, r = 2%. A call.</div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 6. MONTE CARLO — SHOWPIECE                                   -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🎲 Proof by simulation: Monte-Carlo onto Black–Scholes</h3>
+  <p style="margin-top:0">
+    If the price really is a risk-neutral expectation, we should be able to <em>just sample it</em>. Draw
+    thousands of terminal prices S<sub>T</sub> from the log-normal, take each discounted payoff, and
+    average. By the law of large numbers that running average must crawl onto the closed-form
+    Black–Scholes price. Press start and watch the noisy estimate home in on the dashed line:
+  </p>
+  <div class="se-equation">
+    <span class="big">Ĉ<sub>N</sub> = (e<sup>&minus;rT</sup>/N) &Sigma;<sub>i=1…N</sub> max(S<sub>T</sub><sup>(i)</sup> &minus; K, 0) &nbsp;&xrarr;&nbsp; C<sub>BS</sub></span>
+  </div>
+
+  <div class="ot-toggle">
+    <button class="se-btn" id="ot6-start">▶ Start</button>
+    <button class="se-btn sec" id="ot6-step">Step +500</button>
+    <button class="se-reset" id="ot6-reset">Reset</button>
+    <span style="flex:1"></span>
+    <span class="nm" style="font-size:0.8rem;align-self:center">speed</span>
+    <input type="range" id="ot6-speed" min="1" max="10" value="5" style="width:90px;align-self:center">
+  </div>
+
+  <div class="ot-flexwrap">
+    <div class="ot-panel" style="flex:2">
+      <div class="se-chartwrap"><svg id="ot6-svg" width="100%" height="260" viewBox="0 0 480 260"></svg></div>
+      <div class="ot-legend">
+        <span style="color:var(--sn-good)">running estimate Ĉ<sub>N</sub></span>
+        <span style="color:var(--sn-accent)">Black–Scholes C</span>
+        <span style="color:var(--sn-muted)">histogram of S<sub>T</sub></span>
+      </div>
+    </div>
+    <div class="ot-panel">
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">samples N</div><div class="val" id="ot6-n" style="font-size:1.3rem">0</div></div>
+        <div class="ot-stat"><div class="lab">estimate</div><div class="val good" id="ot6-est">&mdash;</div></div>
+      </div>
+      <div class="ot-statrow">
+        <div class="ot-stat"><div class="lab">Black–Scholes</div><div class="val" id="ot6-bs">&mdash;</div></div>
+        <div class="ot-stat"><div class="lab">rel. error</div><div class="val" id="ot6-err">&mdash;</div></div>
+      </div>
+      <div class="ot-msg" id="ot6-msg">S₀ = K = 100, r = 2%, &sigma; = 25%, T = 1. A call.</div>
+    </div>
+  </div>
+</div>
+
+<div class="se-note">
+  <strong>The whole arc in one breath.</strong> A payoff is a bet bent at the strike → its fair price is
+  the discounted, risk-neutral <em>expectation</em> of that bet → because the bet is convex, volatility
+  is what you're really buying → a hedging argument turns that expectation into the Black–Scholes PDE and
+  its two-normal solution → the Greeks are how that solution moves → and a few thousand random draws
+  reproduce the price from scratch. No act of faith required.
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // ---- theme-aware colors ----
+  const SN = document.querySelector(".study-note");
+  const readCols = () => { const cs = getComputedStyle(SN); const c = n => cs.getPropertyValue(n).trim();
+    return { accent: c("--sn-accent"), accentSoft: c("--sn-accent-soft"), good: c("--sn-good"),
+             bad: c("--sn-bad"), warn: c("--sn-warn"), muted: c("--sn-muted"), grid: c("--sn-grid"),
+             panel: c("--sn-panel") }; };
+  let COL = readCols();
+  const redrawFns = [];
+  const onTheme = fn => { redrawFns.push(fn); return fn; };
+  new MutationObserver(() => { COL = readCols(); redrawFns.forEach(f => f()); })
+    .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+
+  // ---- math helpers ----
+  const SQRT2PI = Math.sqrt(2 * Math.PI);
+  function erf(x) { // Abramowitz & Stegun 7.1.26
+    const s = x < 0 ? -1 : 1; x = Math.abs(x);
+    const t = 1 / (1 + 0.3275911 * x);
+    const y = 1 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t * Math.exp(-x * x);
+    return s * y;
+  }
+  const normCdf = x => 0.5 * (1 + erf(x / Math.SQRT2));
+  const normPdf = x => Math.exp(-0.5 * x * x) / SQRT2PI;
+
+  function bs(S, K, r, sig, T, type) {
+    type = type || "call";
+    if (T <= 1e-9 || sig <= 1e-9) {            // degenerate: pure intrinsic
+      const intr = type === "call" ? Math.max(S - K, 0) : Math.max(K - S, 0);
+      const delta = type === "call" ? (S > K ? 1 : 0) : (S < K ? -1 : 0);
+      return { price: intr, d1: NaN, d2: NaN, delta: delta, gamma: 0, vega: 0, theta: 0, rho: 0, Nd1: NaN, Nd2: NaN };
+    }
+    const vt = sig * Math.sqrt(T);
+    const d1 = (Math.log(S / K) + (r + 0.5 * sig * sig) * T) / vt;
+    const d2 = d1 - vt;
+    const Nd1 = normCdf(d1), Nd2 = normCdf(d2), nd1 = normPdf(d1);
+    const disc = Math.exp(-r * T);
+    let price, delta, theta, rho;
+    if (type === "call") {
+      price = S * Nd1 - K * disc * Nd2;
+      delta = Nd1;
+      theta = (-S * nd1 * sig) / (2 * Math.sqrt(T)) - r * K * disc * Nd2;
+      rho = K * T * disc * Nd2;
+    } else {
+      price = K * disc * normCdf(-d2) - S * normCdf(-d1);
+      delta = Nd1 - 1;
+      theta = (-S * nd1 * sig) / (2 * Math.sqrt(T)) + r * K * disc * normCdf(-d2);
+      rho = -K * T * disc * normCdf(-d2);
+    }
+    const gamma = nd1 / (S * vt);
+    const vega = S * nd1 * Math.sqrt(T);
+    return { price, d1, d2, delta, gamma, vega, theta, rho, Nd1, Nd2 };
+  }
+
+  // standard-normal sampler (Box–Muller)
+  let spare = null;
+  function randn() {
+    if (spare !== null) { const v = spare; spare = null; return v; }
+    let u, v, s;
+    do { u = Math.random() * 2 - 1; v = Math.random() * 2 - 1; s = u * u + v * v; } while (s >= 1 || s === 0);
+    const m = Math.sqrt(-2 * Math.log(s) / s);
+    spare = v * m; return u * m;
+  }
+
+  // ---- small SVG plotting helpers ----
+  const SVGNS = "http://www.w3.org/2000/svg";
+  const pathOf = pts => pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" ");
+  function frame(W, H, padL, padR, padT, padB) {
+    return { W, H, padL, padR, padT, padB,
+      xAt(v, lo, hi) { return padL + (v - lo) / (hi - lo) * (W - padL - padR); },
+      yAt(v, lo, hi) { return H - padB - (v - lo) / (hi - lo) * (H - padT - padB); } };
+  }
+  function axes(f, xticks, yticks, xfmt, yfmt) {
+    let g = "";
+    xticks.forEach(t => {
+      g += `<line x1="${t.x}" y1="${f.padT}" x2="${t.x}" y2="${f.H - f.padB}" stroke="${COL.grid}" stroke-width="1"/>`;
+      g += `<text x="${t.x}" y="${f.H - f.padB + 15}" font-size="10" text-anchor="middle">${xfmt(t.v)}</text>`;
+    });
+    yticks.forEach(t => {
+      g += `<line x1="${f.padL}" y1="${t.y}" x2="${f.W - f.padR}" y2="${t.y}" stroke="${COL.grid}" stroke-width="1"/>`;
+      g += `<text x="${f.padL - 6}" y="${t.y + 3}" font-size="10" text-anchor="end">${yfmt(t.v)}</text>`;
+    });
+    return g;
+  }
+
+  // ============================================================
+  // DEMO 1 — payoff & P/L
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ot1-svg");
+    const sS = document.getElementById("ot1-s"), kS = document.getElementById("ot1-k"), pS = document.getElementById("ot1-prem");
+    const sV = document.getElementById("ot1-sv"), kV = document.getElementById("ot1-kv"), pV = document.getElementById("ot1-pv");
+    const moneyEl = document.getElementById("ot1-money"), beEl = document.getElementById("ot1-be"), msg = document.getElementById("ot1-msg");
+    const bCall = document.getElementById("ot1-call"), bPut = document.getElementById("ot1-put");
+    const bLong = document.getElementById("ot1-long"), bShort = document.getElementById("ot1-short");
+    let type = "call", side = 1; // side 1 long, -1 short
+
+    function setBtns() {
+      bCall.className = type === "call" ? "se-btn" : "se-btn sec";
+      bPut.className = type === "put" ? "se-btn" : "se-btn sec";
+      bLong.className = side === 1 ? "se-btn" : "se-btn sec";
+      bShort.className = side === -1 ? "se-btn" : "se-btn sec";
+    }
+    const payoff = (st, K) => type === "call" ? Math.max(st - K, 0) : Math.max(K - st, 0);
+
+    const f = frame(480, 260, 46, 16, 16, 38);
+    const SMAX = 200;
+
+    function draw() {
+      const S = +sS.value, K = +kS.value, prem = +pS.value / 10;
+      sV.textContent = S; kV.textContent = K; pV.textContent = prem.toFixed(1);
+
+      // y-range of P/L: include extremes
+      const plAt = st => side * (payoff(st, K) - prem);
+      let lo = Infinity, hi = -Infinity;
+      for (let st = 0; st <= SMAX; st += 4) { const v = plAt(st); lo = Math.min(lo, v); hi = Math.max(hi, v); const py = payoff(st, K) * side; lo = Math.min(lo, py); hi = Math.max(hi, py); }
+      lo = Math.min(lo, 0); hi = Math.max(hi, 0);
+      const pad = (hi - lo) * 0.1 || 10; lo -= pad; hi += pad;
+
+      const xT = [0, 50, 100, 150, 200].map(v => ({ v, x: f.xAt(v, 0, SMAX) }));
+      const yvals = [];
+      const step = niceStep((hi - lo) / 5);
+      for (let v = Math.ceil(lo / step) * step; v <= hi; v += step) yvals.push(v);
+      const yT = yvals.map(v => ({ v, y: f.yAt(v, lo, hi) }));
+
+      const payPts = [], plPts = [];
+      for (let st = 0; st <= SMAX; st += 2) { payPts.push([f.xAt(st, 0, SMAX), f.yAt(payoff(st, K) * side, lo, hi)]); plPts.push([f.xAt(st, 0, SMAX), f.yAt(plAt(st), lo, hi)]); }
+
+      const zeroY = f.yAt(0, lo, hi);
+      const kx = f.xAt(K, 0, SMAX), sx = f.xAt(S, 0, SMAX);
+
+      let out = axes(f, xT, yT, v => v, v => v.toFixed(0));
+      out += `<line x1="${f.padL}" y1="${zeroY}" x2="${f.W - f.padR}" y2="${zeroY}" stroke="${COL.muted}" stroke-width="1"/>`;
+      out += `<line x1="${kx}" y1="${f.padT}" x2="${kx}" y2="${f.H - f.padB}" stroke="${COL.bad}" stroke-width="1.4" stroke-dasharray="3 3"/>`;
+      out += `<text x="${kx}" y="${f.padT - 3}" font-size="10" fill="${COL.bad}" text-anchor="middle" font-weight="700">K</text>`;
+      out += `<line x1="${sx}" y1="${f.padT}" x2="${sx}" y2="${f.H - f.padB}" stroke="${COL.accent}" stroke-width="1" stroke-dasharray="1 3" opacity="0.6"/>`;
+      out += `<path d="${pathOf(payPts)}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>`;
+      out += `<path d="${pathOf(plPts)}" fill="none" stroke="${COL.good}" stroke-width="2" stroke-dasharray="5 4"/>`;
+      out += `<text x="${(f.padL + f.W - f.padR) / 2}" y="${f.H - 4}" font-size="11" text-anchor="middle">stock price at expiry  Sₜ</text>`;
+      svg.innerHTML = out;
+
+      // moneyness (from the option holder's economic view, ignoring side)
+      const itm = type === "call" ? S > K : S < K;
+      const atm = Math.abs(S - K) <= 2;
+      moneyEl.textContent = atm ? "ATM" : (itm ? "ITM" : "OTM");
+      moneyEl.className = "val " + (atm ? "" : (itm ? "good" : "bad"));
+      moneyEl.style.fontSize = "1.1rem";
+      const be = type === "call" ? K + prem : K - prem;
+      beEl.textContent = be.toFixed(1);
+
+      const who = side === 1 ? "You bought" : "You sold";
+      const dir = type === "call" ? "rises above" : "falls below";
+      msg.innerHTML = `${who} a ${type}. ` + (side === 1
+        ? `Risk is capped at the &minus;${prem.toFixed(1)} premium; you profit once S<sub>T</sub> ${dir} the breakeven ${be.toFixed(1)}.`
+        : `You keep the ${prem.toFixed(1)} premium unless S<sub>T</sub> ${dir} ${be.toFixed(1)} — then losses run the other way.`);
+    }
+
+    bCall.onclick = () => { type = "call"; setBtns(); draw(); };
+    bPut.onclick = () => { type = "put"; setBtns(); draw(); };
+    bLong.onclick = () => { side = 1; setBtns(); draw(); };
+    bShort.onclick = () => { side = -1; setBtns(); draw(); };
+    [sS, kS, pS].forEach(el => el.addEventListener("input", draw));
+    setBtns(); onTheme(draw); draw();
+  })();
+
+  function niceStep(raw) {
+    const p = Math.pow(10, Math.floor(Math.log10(raw)));
+    const n = raw / p;
+    return (n < 1.5 ? 1 : n < 3 ? 2 : n < 7 ? 5 : 10) * p;
+  }
+
+  // ============================================================
+  // DEMO 2 — intrinsic vs time value
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ot2-svg");
+    const tS = document.getElementById("ot2-t"), volS = document.getElementById("ot2-vol");
+    const tV = document.getElementById("ot2-tv"), volV = document.getElementById("ot2-volv");
+    const priceEl = document.getElementById("ot2-price"), tvalEl = document.getElementById("ot2-tval"), msg = document.getElementById("ot2-msg");
+    const K = 100, r = 0.02, f = frame(480, 260, 40, 16, 16, 38), SMAX = 200;
+
+    function draw() {
+      const T = +tS.value / 100, sig = +volS.value / 100;
+      tV.textContent = T.toFixed(2); volV.textContent = sig.toFixed(2);
+      const ymax = bs(SMAX, K, r, sig, T, "call").price * 1.05 || 100;
+      const xT = [0, 50, 100, 150, 200].map(v => ({ v, x: f.xAt(v, 0, SMAX) }));
+      const yT = []; const step = niceStep(ymax / 5);
+      for (let v = 0; v <= ymax; v += step) yT.push({ v, y: f.yAt(v, 0, ymax) });
+
+      const payPts = [], prPts = [], band = [];
+      for (let st = 0; st <= SMAX; st += 2) {
+        const intr = Math.max(st - K, 0), pr = bs(st, K, r, sig, T, "call").price;
+        payPts.push([f.xAt(st, 0, SMAX), f.yAt(intr, 0, ymax)]);
+        prPts.push([f.xAt(st, 0, SMAX), f.yAt(pr, 0, ymax)]);
+      }
+      // time-value band = area between price and payoff
+      for (let st = 0; st <= SMAX; st += 2) band.push([f.xAt(st, 0, SMAX), f.yAt(bs(st, K, r, sig, T, "call").price, 0, ymax)]);
+      for (let st = SMAX; st >= 0; st -= 2) band.push([f.xAt(st, 0, SMAX), f.yAt(Math.max(st - K, 0), 0, ymax)]);
+
+      let out = axes(f, xT, yT, v => v, v => v.toFixed(0));
+      out += `<path d="${pathOf(band)} Z" fill="${COL.warn}" opacity="0.14" stroke="none"/>`;
+      out += `<path d="${pathOf(payPts)}" fill="none" stroke="${COL.muted}" stroke-width="1.6" stroke-dasharray="4 3"/>`;
+      out += `<path d="${pathOf(prPts)}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>`;
+      out += `<text x="${(f.padL + f.W - f.padR) / 2}" y="${f.H - 4}" font-size="11" text-anchor="middle">spot S</text>`;
+      svg.innerHTML = out;
+
+      const atm = bs(K, K, r, sig, T, "call");
+      priceEl.textContent = atm.price.toFixed(2);
+      tvalEl.textContent = atm.price.toFixed(2); // ATM intrinsic ≈ 0
+      tvalEl.className = "val warn";
+      msg.innerHTML = T < 0.05
+        ? "Almost no time left: the curve has collapsed onto the payoff. Time value &asymp; 0."
+        : `K = 100, r = 2%. At expiry the whole orange gap (time value) decays to zero.`;
+    }
+    [tS, volS].forEach(el => el.addEventListener("input", draw));
+    onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 3 — volatility / risk-neutral expectation
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ot3-svg");
+    const volS = document.getElementById("ot3-vol"), volV = document.getElementById("ot3-volv");
+    const numEl = document.getElementById("ot3-num"), bsEl = document.getElementById("ot3-bs");
+    const S0 = 100, K = 100, r = 0.02, T = 1, f = frame(480, 260, 40, 16, 16, 38), SMAX = 260;
+
+    function draw() {
+      const sig = +volS.value / 100; volV.textContent = sig.toFixed(2);
+      const vt = sig * Math.sqrt(T);
+      const mu = Math.log(S0) + (r - 0.5 * sig * sig) * T;       // lognormal params of S_T
+      const dens = x => x <= 0 ? 0 : Math.exp(-Math.pow(Math.log(x) - mu, 2) / (2 * vt * vt)) / (x * vt * SQRT2PI);
+
+      // numeric discounted E[payoff]
+      let acc = 0; const dx = 0.5;
+      for (let x = dx / 2; x < 600; x += dx) acc += Math.max(x - K, 0) * dens(x) * dx;
+      const numV = Math.exp(-r * T) * acc;
+      numEl.textContent = numV.toFixed(2);
+      bsEl.textContent = bs(S0, K, r, sig, T, "call").price.toFixed(2);
+
+      // scale density to plot height; value curve = payoff*density (own scale, shown relative)
+      let dmax = 0; for (let x = 1; x <= SMAX; x += 2) dmax = Math.max(dmax, dens(x));
+      const dPts = [], vPts = []; let vmax = 0;
+      for (let x = 0; x <= SMAX; x += 2) { const vv = Math.max(x - K, 0) * dens(x); if (vv > vmax) vmax = vv; }
+      const xT = [0, 50, 100, 150, 200, 250].map(v => ({ v, x: f.xAt(v, 0, SMAX) }));
+      for (let x = 0; x <= SMAX; x += 2) {
+        dPts.push([f.xAt(x, 0, SMAX), f.yAt(dens(x) / dmax, 0, 1.08)]);
+        vPts.push([f.xAt(x, 0, SMAX), f.yAt((Math.max(x - K, 0) * dens(x)) / (vmax || 1) * 0.85, 0, 1.08)]);
+      }
+      // shaded value area
+      const area = vPts.slice();
+      area.push([f.xAt(SMAX, 0, SMAX), f.yAt(0, 0, 1.08)]);
+      area.push([f.xAt(0, 0, SMAX), f.yAt(0, 0, 1.08)]);
+
+      const kx = f.xAt(K, 0, SMAX);
+      let out = axes(f, xT, [], v => v, v => v);
+      out += `<path d="${pathOf(area)} Z" fill="${COL.good}" opacity="0.16" stroke="none"/>`;
+      out += `<line x1="${kx}" y1="${f.padT}" x2="${kx}" y2="${f.H - f.padB}" stroke="${COL.bad}" stroke-width="1.4" stroke-dasharray="3 3"/>`;
+      out += `<text x="${kx}" y="${f.padT - 3}" font-size="10" fill="${COL.bad}" text-anchor="middle" font-weight="700">K</text>`;
+      out += `<path d="${pathOf(dPts)}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>`;
+      out += `<path d="${pathOf(vPts)}" fill="none" stroke="${COL.good}" stroke-width="1.8"/>`;
+      out += `<text x="${(f.padL + f.W - f.padR) / 2}" y="${f.H - 4}" font-size="11" text-anchor="middle">terminal price Sₜ</text>`;
+      svg.innerHTML = out;
+    }
+    volS.addEventListener("input", draw); onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 4 — Black–Scholes pricing
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ot4-svg");
+    const sS = document.getElementById("ot4-s"), kS = document.getElementById("ot4-k"), volS = document.getElementById("ot4-vol"), tS = document.getElementById("ot4-t"), rS = document.getElementById("ot4-r");
+    const sV = document.getElementById("ot4-sv"), kV = document.getElementById("ot4-kv"), volV = document.getElementById("ot4-volv"), tV = document.getElementById("ot4-tv"), rV = document.getElementById("ot4-rv");
+    const priceEl = document.getElementById("ot4-price"), d1El = document.getElementById("ot4-d1"), d2El = document.getElementById("ot4-d2"), nd1El = document.getElementById("ot4-nd1"), nd2El = document.getElementById("ot4-nd2");
+    const bCall = document.getElementById("ot4-call"), bPut = document.getElementById("ot4-put");
+    let type = "call";
+    const f = frame(480, 260, 40, 16, 16, 38), SMAX = 200;
+    const setBtns = () => { bCall.className = type === "call" ? "se-btn" : "se-btn sec"; bPut.className = type === "put" ? "se-btn" : "se-btn sec"; };
+
+    function draw() {
+      const S = +sS.value, K = +kS.value, sig = +volS.value / 100, T = +tS.value / 100, r = +rS.value / 1000;
+      sV.textContent = S; kV.textContent = K; volV.textContent = sig.toFixed(2); tV.textContent = T.toFixed(2); rV.textContent = r.toFixed(3);
+      const o = bs(S, K, r, sig, T, type);
+      priceEl.textContent = o.price.toFixed(2);
+      d1El.textContent = isNaN(o.d1) ? "—" : o.d1.toFixed(2);
+      d2El.textContent = isNaN(o.d2) ? "—" : o.d2.toFixed(2);
+      nd1El.textContent = isNaN(o.Nd1) ? "—" : o.Nd1.toFixed(3);
+      nd2El.textContent = isNaN(o.Nd2) ? "—" : o.Nd2.toFixed(3);
+
+      const intr = st => type === "call" ? Math.max(st - K, 0) : Math.max(K - st, 0);
+      let ymax = 0; for (let st = 0; st <= SMAX; st += 4) ymax = Math.max(ymax, bs(st, K, r, sig, T, type).price, intr(st));
+      ymax = ymax * 1.08 || 100;
+      const xT = [0, 50, 100, 150, 200].map(v => ({ v, x: f.xAt(v, 0, SMAX) }));
+      const yT = []; const step = niceStep(ymax / 5);
+      for (let v = 0; v <= ymax; v += step) yT.push({ v, y: f.yAt(v, 0, ymax) });
+
+      const prPts = [], payPts = [];
+      for (let st = 0; st <= SMAX; st += 2) { prPts.push([f.xAt(st, 0, SMAX), f.yAt(bs(st, K, r, sig, T, type).price, 0, ymax)]); payPts.push([f.xAt(st, 0, SMAX), f.yAt(intr(st), 0, ymax)]); }
+      const sx = f.xAt(S, 0, SMAX);
+      let out = axes(f, xT, yT, v => v, v => v.toFixed(0));
+      out += `<path d="${pathOf(payPts)}" fill="none" stroke="${COL.muted}" stroke-width="1.6" stroke-dasharray="4 3"/>`;
+      out += `<path d="${pathOf(prPts)}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>`;
+      out += `<line x1="${sx}" y1="${f.padT}" x2="${sx}" y2="${f.H - f.padB}" stroke="${COL.bad}" stroke-width="1.2" stroke-dasharray="3 3"/>`;
+      out += `<circle cx="${sx}" cy="${f.yAt(o.price, 0, ymax)}" r="4" fill="${COL.accent}"/>`;
+      out += `<text x="${(f.padL + f.W - f.padR) / 2}" y="${f.H - 4}" font-size="11" text-anchor="middle">spot S</text>`;
+      svg.innerHTML = out;
+    }
+    bCall.onclick = () => { type = "call"; setBtns(); draw(); };
+    bPut.onclick = () => { type = "put"; setBtns(); draw(); };
+    [sS, kS, volS, tS, rS].forEach(el => el.addEventListener("input", draw));
+    setBtns(); onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 5 — the Greeks
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ot5-svg");
+    const sS = document.getElementById("ot5-s"), volS = document.getElementById("ot5-vol"), tS = document.getElementById("ot5-t");
+    const sV = document.getElementById("ot5-sv"), volV = document.getElementById("ot5-volv"), tV = document.getElementById("ot5-tv");
+    const dEl = document.getElementById("ot5-delta"), gEl = document.getElementById("ot5-gamma"), thEl = document.getElementById("ot5-theta"), vEl = document.getElementById("ot5-vega"), rhEl = document.getElementById("ot5-rho");
+    const K = 100, r = 0.02, f = frame(480, 260, 40, 16, 16, 38), SMIN = 40, SMAX = 160;
+
+    function draw() {
+      const S = +sS.value, sig = +volS.value / 100, T = +tS.value / 100;
+      sV.textContent = S; volV.textContent = sig.toFixed(2); tV.textContent = T.toFixed(2);
+      const o = bs(S, K, r, sig, T, "call");
+      dEl.textContent = o.delta.toFixed(3);
+      gEl.textContent = o.gamma.toFixed(4);
+      thEl.textContent = (o.theta / 365).toFixed(3); thEl.className = "val bad";
+      vEl.textContent = (o.vega / 100).toFixed(3);
+      rhEl.textContent = (o.rho / 100).toFixed(3);
+
+      let ymax = 0; for (let st = SMIN; st <= SMAX; st += 2) ymax = Math.max(ymax, bs(st, K, r, sig, T, "call").price);
+      ymax *= 1.1;
+      const xT = [40, 70, 100, 130, 160].map(v => ({ v, x: f.xAt(v, SMIN, SMAX) }));
+      const yT = []; const step = niceStep(ymax / 5);
+      for (let v = 0; v <= ymax; v += step) yT.push({ v, y: f.yAt(v, 0, ymax) });
+
+      const prPts = [];
+      for (let st = SMIN; st <= SMAX; st += 1) prPts.push([f.xAt(st, SMIN, SMAX), f.yAt(bs(st, K, r, sig, T, "call").price, 0, ymax)]);
+
+      // tangent at S: line through (S, price) with slope delta (in price units per spot unit)
+      const x1 = SMIN, x2 = SMAX;
+      const y1 = o.price + o.delta * (x1 - S), y2 = o.price + o.delta * (x2 - S);
+      const sx = f.xAt(S, SMIN, SMAX);
+
+      let out = axes(f, xT, yT, v => v, v => v.toFixed(0));
+      out += `<line x1="${f.xAt(x1, SMIN, SMAX)}" y1="${f.yAt(y1, 0, ymax)}" x2="${f.xAt(x2, SMIN, SMAX)}" y2="${f.yAt(y2, 0, ymax)}" stroke="${COL.warn}" stroke-width="1.6" stroke-dasharray="5 4"/>`;
+      out += `<path d="${pathOf(prPts)}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>`;
+      out += `<line x1="${sx}" y1="${f.padT}" x2="${sx}" y2="${f.H - f.padB}" stroke="${COL.bad}" stroke-width="1.2" stroke-dasharray="3 3"/>`;
+      out += `<circle cx="${sx}" cy="${f.yAt(o.price, 0, ymax)}" r="4.5" fill="${COL.accent}"/>`;
+      out += `<text x="${(f.padL + f.W - f.padR) / 2}" y="${f.H - 4}" font-size="11" text-anchor="middle">spot S</text>`;
+      svg.innerHTML = out;
+    }
+    [sS, volS, tS].forEach(el => el.addEventListener("input", draw));
+    onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 6 — Monte Carlo convergence
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ot6-svg");
+    const bStart = document.getElementById("ot6-start"), bStep = document.getElementById("ot6-step"), bReset = document.getElementById("ot6-reset"), speed = document.getElementById("ot6-speed");
+    const nEl = document.getElementById("ot6-n"), estEl = document.getElementById("ot6-est"), bsEl = document.getElementById("ot6-bs"), errEl = document.getElementById("ot6-err");
+    const S0 = 100, K = 100, r = 0.02, sig = 0.25, T = 1;
+    const C = bs(S0, K, r, sig, T, "call").price;
+    const disc = Math.exp(-r * T), drift = (r - 0.5 * sig * sig) * T, vol = sig * Math.sqrt(T);
+    const f = frame(480, 260, 44, 16, 16, 38);
+    const NMAX = 100000;
+
+    let n = 0, sum = 0, running = [];      // running[]: [N, estimate]
+    const NBINS = 40, binLo = 20, binHi = 240, bins = new Array(NBINS).fill(0); let binMax = 0;
+    let timer = null;
+
+    function sampleOne() {
+      const st = S0 * Math.exp(drift + vol * randn());
+      sum += Math.max(st - K, 0); n++;
+      const bi = Math.max(0, Math.min(NBINS - 1, Math.floor((st - binLo) / (binHi - binLo) * NBINS)));
+      bins[bi]++; if (bins[bi] > binMax) binMax = bins[bi];
+    }
+    function batch(k) {
+      for (let i = 0; i < k && n < NMAX; i++) sampleOne();
+      const est = disc * sum / Math.max(n, 1);
+      // log-spaced sampling of the running curve for a stable plot
+      if (running.length === 0 || n >= running[running.length - 1][0] * 1.04 || n >= NMAX) running.push([n, est]);
+      update(est);
+    }
+    function update(est) {
+      nEl.textContent = n.toLocaleString();
+      estEl.textContent = n ? est.toFixed(3) : "—";
+      bsEl.textContent = C.toFixed(3);
+      errEl.textContent = n ? (100 * Math.abs(est - C) / C).toFixed(2) + "%" : "—";
+      draw();
+    }
+
+    function draw() {
+      // top 2/3: convergence curve (log x). bottom 1/3: histogram.
+      const splitY = f.padT + (f.H - f.padT - f.padB) * 0.62;
+      const xLo = Math.log10(10), xHi = Math.log10(NMAX);
+      const cy = { yAt(v, lo, hi) { return splitY - (v - lo) / (hi - lo) * (splitY - f.padT); } };
+      const cx = v => f.padL + (Math.log10(Math.max(v, 10)) - xLo) / (xHi - xLo) * (f.W - f.padL - f.padR);
+
+      const yLo = C * 0.4, yHi = C * 1.6;
+      let out = "";
+      // y grid for convergence
+      [C * 0.5, C * 0.75, C, C * 1.25, C * 1.5].forEach(v => {
+        const y = cy.yAt(v, yLo, yHi);
+        out += `<line x1="${f.padL}" y1="${y}" x2="${f.W - f.padR}" y2="${y}" stroke="${COL.grid}" stroke-width="1"/>`;
+        out += `<text x="${f.padL - 6}" y="${y + 3}" font-size="9" text-anchor="end">${v.toFixed(1)}</text>`;
+      });
+      [10, 100, 1000, 10000, 100000].forEach(v => {
+        out += `<text x="${cx(v)}" y="${splitY + 13}" font-size="9" text-anchor="middle">${v >= 1000 ? (v / 1000) + "k" : v}</text>`;
+      });
+      // BS target line
+      const tY = cy.yAt(C, yLo, yHi);
+      out += `<line x1="${f.padL}" y1="${tY}" x2="${f.W - f.padR}" y2="${tY}" stroke="${COL.accent}" stroke-width="1.6" stroke-dasharray="6 4"/>`;
+      out += `<text x="${f.W - f.padR}" y="${tY - 4}" font-size="9" fill="${COL.accent}" text-anchor="end">C = ${C.toFixed(2)}</text>`;
+      // running estimate
+      if (running.length > 1) {
+        const pts = running.map(p => [cx(p[0]), cy.yAt(Math.max(yLo, Math.min(yHi, p[1])), yLo, yHi)]);
+        out += `<path d="${pathOf(pts)}" fill="none" stroke="${COL.good}" stroke-width="2"/>`;
+        const last = pts[pts.length - 1];
+        out += `<circle cx="${last[0]}" cy="${last[1]}" r="3.5" fill="${COL.good}"/>`;
+      }
+      out += `<text x="${f.padL}" y="${f.padT + 2}" font-size="9" fill="${COL.muted}">estimate vs samples (log scale)</text>`;
+
+      // histogram (bottom)
+      const hTop = splitY + 22, hBot = f.H - f.padB + 0;
+      const bw = (f.W - f.padL - f.padR) / NBINS;
+      for (let i = 0; i < NBINS; i++) {
+        if (!bins[i]) continue;
+        const h = bins[i] / binMax * (hBot - hTop);
+        out += `<rect x="${(f.padL + i * bw).toFixed(1)}" y="${(hBot - h).toFixed(1)}" width="${(bw - 1).toFixed(1)}" height="${h.toFixed(1)}" fill="${COL.muted}" opacity="0.5"/>`;
+      }
+      const kx = f.padL + (K - binLo) / (binHi - binLo) * (f.W - f.padL - f.padR);
+      out += `<line x1="${kx}" y1="${hTop}" x2="${kx}" y2="${hBot}" stroke="${COL.bad}" stroke-width="1.2" stroke-dasharray="3 3"/>`;
+      out += `<text x="${kx}" y="${hBot + 12}" font-size="9" fill="${COL.bad}" text-anchor="middle">K  (Sₜ →)</text>`;
+      svg.innerHTML = out;
+    }
+
+    function loop() {
+      const k = [0, 30, 80, 160, 300, 500, 800, 1200, 1800, 2600, 4000][+speed.value];
+      batch(k);
+      if (n >= NMAX) { stop(); return; }
+      timer = requestAnimationFrame(loop);
+    }
+    function start() { if (timer) return; bStart.textContent = "⏸ Pause"; timer = requestAnimationFrame(loop); }
+    function stop() { if (timer) cancelAnimationFrame(timer); timer = null; bStart.textContent = n >= NMAX ? "▶ Start" : "▶ Resume"; }
+    function reset() { stop(); n = 0; sum = 0; running = []; bins.fill(0); binMax = 0; bStart.textContent = "▶ Start"; update(0); }
+
+    bStart.onclick = () => { timer ? stop() : start(); };
+    bStep.onclick = () => { stop(); batch(500); };
+    bReset.onclick = reset;
+    onTheme(draw);
+    reset();
+  })();
+
+})();
+</script>
+
+</div>


### PR DESCRIPTION
Add a self-contained interactive explainer covering options from payoff
diagrams through Black-Scholes and the Greeks, in the existing study-note
design system. Six draggable SVG demos: payoff/P&L, intrinsic vs time
value, the volatility/risk-neutral-expectation keystone, Black-Scholes
pricing, the five Greeks (delta as slope, gamma as curvature), and a
Monte-Carlo simulator whose discounted average payoff converges onto the
closed-form price.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wrq2NfK18eFYTVnxvVfGiR