### PR TITLE
Add study note: how many coin tosses to catch a rigged coin

### DIFF
--- a/docs/_posts/2026-06-19-how-many-tosses-rigged-coin.html
+++ b/docs/_posts/2026-06-19-how-many-tosses-rigged-coin.html
@@ -1,0 +1,780 @@
+---
+layout: post
+title: "How Many Coin Tosses to Catch a Rigged Coin?"
+date: 2026-06-19
+categories: [Statistics, Interactive]
+excerpt: "A friend swears the coin is fair; you suspect it leans heads. How many flips would actually settle it? Flip a coin live and watch the evidence pile up, see a p-value light up, push the false-alarm and missed-detection curves apart, then read off the exact number from one clean formula — and confirm it with a thousand simulated experiments. The punchline: near-fair coins are brutally expensive to expose, and the cost scales like 1/(p−½)²."
+---
+
+{% include study-note-styles.html %}
+
+<div class="study-note">
+
+<style>
+/* Note-specific LAYOUT only — colors/components come from study-note-styles.html.
+   Unique prefix `ct-` (coin toss) avoids collisions with se-/bm-/mdp- notes. */
+.ct-flexwrap { display: flex; gap: 1.25rem; flex-wrap: wrap; align-items: flex-start; }
+.ct-panel { flex: 1; min-width: 240px; }
+
+.ct-controls { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
+
+.ct-ctrlrow { display: grid; grid-template-columns: 124px 1fr 70px; gap: 0.6rem; align-items: center; margin: 0.55rem 0; }
+.ct-ctrlrow .nm { font-size: 0.85rem; }
+.ct-ctrlrow .pv { font-size: 0.85rem; text-align: right; font-family: var(--sn-mono); font-variant-numeric: tabular-nums; color: var(--sn-accent); font-weight: 600; }
+
+.ct-readout { font-family: var(--sn-mono); font-variant-numeric: tabular-nums; font-weight: 600; color: var(--sn-accent); min-width: 3rem; display: inline-block; }
+
+.ct-statrow { display: flex; gap: 2rem; justify-content: center; margin: 0.6rem 0; flex-wrap: wrap; }
+.ct-stat { text-align: center; }
+.ct-stat .lab { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; }
+.ct-stat .val { font-family: var(--sn-mono); font-variant-numeric: tabular-nums; color: var(--sn-accent); font-weight: 700; font-size: 1.7rem; line-height: 1.1; letter-spacing: -0.02em; }
+
+.ct-legend { font-size: 0.78rem; opacity: 0.8; display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 0.4rem; justify-content: center; }
+.ct-legend span::before { content: "■ "; }
+
+/* coin face */
+.ct-coin { width: 54px; height: 54px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 1.4rem; font-weight: 700; font-family: var(--sn-mono); border: 1px solid var(--sn-border); background: var(--sn-panel-inset); color: var(--sn-muted); transition: transform 0.18s var(--sn-ease), color 0.18s var(--sn-ease), background 0.18s var(--sn-ease); }
+.ct-coin.flip { transform: rotateY(180deg) scale(1.08); }
+
+/* progress + comparison bars */
+.ct-bar { background: var(--sn-panel-inset); border: 1px solid var(--sn-border); border-radius: 8px; height: 22px; overflow: hidden; position: relative; }
+.ct-bar > div { height: 100%; border-radius: 8px; transition: width 0.12s linear, background 0.2s ease; }
+.ct-cmprow { display: grid; grid-template-columns: 110px 1fr 64px; gap: 0.6rem; align-items: center; margin: 0.5rem 0; }
+.ct-cmprow .nm { font-size: 0.85rem; }
+.ct-cmprow .pv { font-size: 0.9rem; text-align: right; font-family: var(--sn-mono); font-variant-numeric: tabular-nums; color: var(--sn-accent); font-weight: 700; }
+
+.ct-bignum { font-family: var(--sn-mono); font-variant-numeric: tabular-nums; color: var(--sn-accent); font-weight: 800; font-size: 2.6rem; line-height: 1.05; letter-spacing: -0.03em; text-align: center; }
+</style>
+
+<p>
+  A friend slaps a coin on the table and swears it's fair. You've watched it land heads a little too
+  often and you're not so sure. Here's the deceptively simple question this note is about:
+  <strong>how many times would you have to flip it before you could honestly say it's rigged?</strong>
+</p>
+
+<p>The answer is not a single number — it depends on two things — but it <em>is</em> a clean formula:</p>
+
+<div class="ct-note se-note">
+  <strong>It depends on how rigged the coin is and how sure you want to be.</strong> A wildly biased
+  60/40 coin gives itself away in a couple hundred flips. A barely-rigged 51/49 coin can hide for
+  <em>tens of thousands</em>. The cost of catching it explodes as the bias shrinks — and by the end
+  you'll be able to read the exact number off one equation, then watch a simulation confirm it.
+</div>
+
+<!-- ============================================================ -->
+<!-- 1. FLIP IT AND WATCH THE EVIDENCE                            -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🪙 Flip it and watch the evidence build</h3>
+  <p style="margin-top:0">
+    Set the coin's <em>true</em> bias with the slider (the universe knows it; you don't), then start
+    flipping. The chart tracks the <strong>running fraction of heads</strong>, p&#770;, after every
+    flip. The shaded funnel is the <strong>95% range a genuinely fair coin would stay inside</strong> —
+    it narrows like 1/&radic;n. The moment your trace pokes out of the funnel and stays out, you've got
+    visual evidence the coin isn't fair.
+  </p>
+
+  <div class="ct-flexwrap">
+    <div class="ct-panel" style="flex:2">
+      <div class="se-chartwrap">
+        <svg id="ct1-svg" width="100%" height="260" viewBox="0 0 720 260" preserveAspectRatio="none" style="display:block"></svg>
+      </div>
+      <div class="ct-legend">
+        <span style="color:var(--sn-accent)">running p&#770;</span>
+        <span style="color:var(--sn-muted)">fair = 0.5</span>
+        <span style="color:var(--sn-good)">true bias</span>
+      </div>
+    </div>
+    <div class="ct-panel">
+      <div class="ct-ctrlrow">
+        <span class="nm">true p(heads)</span>
+        <input type="range" id="ct1-p" min="2" max="98" value="55">
+        <span class="pv" id="ct1-pv">0.55</span>
+      </div>
+      <div class="ct-controls">
+        <button class="se-btn" id="ct1-f1">Flip ×1</button>
+        <button class="se-btn sec" id="ct1-f100">Flip ×100</button>
+        <button class="se-reset" id="ct1-reset">↺ Reset</button>
+        <span class="ct-coin" id="ct1-coin">?</span>
+      </div>
+      <div class="ct-statrow">
+        <div class="ct-stat"><div class="lab">flips n</div><div class="val" id="ct1-n">0</div></div>
+        <div class="ct-stat"><div class="lab">heads</div><div class="val" id="ct1-h">0</div></div>
+        <div class="ct-stat"><div class="lab">p&#770;</div><div class="val" id="ct1-phat">—</div></div>
+      </div>
+      <div style="text-align:center;margin-top:0.3rem"><span id="ct1-tag" class="se-tag">flip to begin</span></div>
+    </div>
+  </div>
+
+  <div class="se-note" style="margin-bottom:0">
+    <strong>Try this:</strong> set the bias to 0.55 and flip 100 at a time. Early on the trace lurches
+    all over the place — small samples are <em>noisy</em> — and it often sits comfortably inside the
+    fair funnel for a while. Push past a few hundred flips and it finally separates. Now set the bias to
+    0.70 and watch it escape almost immediately. That gap in difficulty is the whole story.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 2. THE NULL HYPOTHESIS AND THE p-VALUE                       -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>⚖️ The skeptic's question: the null hypothesis &amp; the p-value</h3>
+  <p style="margin-top:0">
+    To <em>prove</em> rigging we start by assuming the opposite — that's how statistics stays honest.
+    The <strong>null hypothesis</strong> is "the coin is fair," H<sub>0</sub>: p = 0.5. Under H<sub>0</sub>
+    the number of heads in n flips follows a <strong>Binomial(n, 0.5)</strong> distribution, and for any
+    decent n that's well approximated by a bell curve. We summarise how far our result lands from the
+    fair center with the <strong>z-score</strong>:
+  </p>
+  <div class="se-equation">
+    <span class="big">z = ( p&#770; &minus; 0.5 ) / &radic;( 0.25 / n )</span>
+  </div>
+  <p style="margin-top:0">
+    The <strong>p-value</strong> is then the probability a perfectly fair coin would look
+    <em>this extreme or more</em>, just by luck. Small p-value = "a fair coin almost never does this" =
+    evidence of rigging. The convention is to raise the alarm when <strong>p &lt; 0.05</strong>. Drag the
+    sample size and the observed fraction of heads and watch the tail area — the p-value — light up:
+  </p>
+
+  <div class="ct-flexwrap">
+    <div class="ct-panel" style="flex:2">
+      <div class="se-chartwrap">
+        <svg id="ct2-svg" width="100%" height="250" viewBox="0 0 720 250" preserveAspectRatio="none" style="display:block"></svg>
+      </div>
+      <div class="ct-legend">
+        <span style="color:var(--sn-accent)">fair-coin distribution</span>
+        <span style="color:var(--sn-bad)">p-value (luck tails)</span>
+      </div>
+    </div>
+    <div class="ct-panel">
+      <div class="ct-ctrlrow">
+        <span class="nm">flips n</span>
+        <input type="range" id="ct2-n" min="10" max="1000" value="100">
+        <span class="pv" id="ct2-nv">100</span>
+      </div>
+      <div class="ct-ctrlrow">
+        <span class="nm">observed p&#770;</span>
+        <input type="range" id="ct2-p" min="2" max="98" value="60">
+        <span class="pv" id="ct2-pv">0.60</span>
+      </div>
+      <div class="ct-statrow">
+        <div class="ct-stat"><div class="lab">heads</div><div class="val" id="ct2-k">60</div></div>
+        <div class="ct-stat"><div class="lab">z-score</div><div class="val" id="ct2-z">—</div></div>
+      </div>
+      <div class="ct-statrow" style="margin-top:0">
+        <div class="ct-stat"><div class="lab">p-value</div><div class="val" id="ct2-pval">—</div></div>
+      </div>
+      <div style="text-align:center;margin-top:0.3rem"><span id="ct2-tag" class="se-tag">—</span></div>
+    </div>
+  </div>
+
+  <div class="ct-flexwrap" style="margin-top:0.5rem">
+    <div class="se-example" style="flex:1;margin:0">
+      <strong>60 heads in 100:</strong> looks lopsided, but a fair coin manages it about 5% of the time —
+      right on the borderline. Not yet damning.
+    </div>
+    <div class="se-example" style="flex:1;margin:0">
+      <strong>600 heads in 1000:</strong> the <em>same</em> 60% fraction, but now p is astronomically
+      small. Same bias, ten times the flips, overwhelming proof. <strong>Evidence is about n, not just
+      the ratio.</strong>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 3. TWO WAYS TO BE WRONG: ALPHA AND POWER                     -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🎯 Two ways to be wrong: false alarms (&alpha;) and missed detections (power)</h3>
+  <p style="margin-top:0">
+    A test can fail in two directions. A <strong>false alarm</strong> (Type I error) is calling a fair
+    coin rigged — its rate is the threshold <strong>&alpha;</strong> we picked above (e.g. 0.05). A
+    <strong>missed detection</strong> (Type II error, rate &beta;) is letting a truly rigged coin walk
+    free. What we really care about is <strong>power = 1 &minus; &beta;</strong>: the chance we
+    <em>catch</em> a rigged coin when it really is rigged.
+  </p>
+  <p style="margin-top:0">
+    Below are two bell curves over p&#770;: the <strong>null</strong> (fair, centered at 0.5) and the
+    <strong>alternative</strong> (the coin's true bias). We reject "fair" whenever p&#770; lands past the
+    critical lines. The <span style="color:var(--sn-bad)">red</span> tails under the null are &alpha;;
+    the <span style="color:var(--sn-good)">green</span> area under the alternative past the line is the
+    power. Crank up n or the bias and watch the curves pull apart — that separation <em>is</em> power.
+  </p>
+
+  <div class="ct-flexwrap">
+    <div class="ct-panel" style="flex:2">
+      <div class="se-chartwrap">
+        <svg id="ct3-svg" width="100%" height="260" viewBox="0 0 720 260" preserveAspectRatio="none" style="display:block"></svg>
+      </div>
+      <div class="ct-legend">
+        <span style="color:var(--sn-accent)">fair (null)</span>
+        <span style="color:var(--sn-good)">true bias (alt) &amp; power</span>
+        <span style="color:var(--sn-bad)">&alpha; (false alarm)</span>
+      </div>
+    </div>
+    <div class="ct-panel">
+      <div class="ct-ctrlrow">
+        <span class="nm">true p(heads)</span>
+        <input type="range" id="ct3-p" min="51" max="85" value="55">
+        <span class="pv" id="ct3-pv">0.55</span>
+      </div>
+      <div class="ct-ctrlrow">
+        <span class="nm">flips n</span>
+        <input type="range" id="ct3-n" min="10" max="2000" value="200">
+        <span class="pv" id="ct3-nv">200</span>
+      </div>
+      <div class="ct-ctrlrow">
+        <span class="nm">&alpha; (×1000)</span>
+        <input type="range" id="ct3-a" min="1" max="200" value="50">
+        <span class="pv" id="ct3-av">0.050</span>
+      </div>
+      <div class="ct-statrow">
+        <div class="ct-stat"><div class="lab">power</div><div class="val" id="ct3-pow">—</div></div>
+        <div class="ct-stat"><div class="lab">&alpha;</div><div class="val" id="ct3-a2" style="color:var(--sn-muted)">—</div></div>
+      </div>
+      <div style="text-align:center;margin-top:0.3rem"><span id="ct3-tag" class="se-tag">—</span></div>
+    </div>
+  </div>
+
+  <div class="se-note" style="margin-bottom:0">
+    <strong>The tug-of-war:</strong> tightening &alpha; (fewer false alarms) pushes the critical lines
+    outward and <em>lowers</em> power. The only way to win on both fronts at once is to collect more
+    data. That trade-off is exactly what the sample-size formula below resolves.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 4. THE PURE-MATH ANSWER: THE SAMPLE-SIZE FORMULA            -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🧮 The pure-math answer: a formula for n</h3>
+  <p style="margin-top:0">
+    Now we just turn the picture into algebra. We want the critical line to sit far enough from the fair
+    center to keep false alarms at &alpha;, <em>and</em> far enough below the true bias to catch it with
+    the power we want. Writing z<sub>&alpha;/2</sub> and z<sub>&beta;</sub> for the standard-normal
+    cutoffs, "push the two curves apart until both conditions hold" rearranges to:
+  </p>
+  <div class="se-equation">
+    <span class="big">n &asymp; ( z<sub>&alpha;/2</sub> &middot; &radic;<span style="text-decoration:overline">&frac14;</span> &nbsp;+&nbsp; z<sub>&beta;</sub> &middot; &radic;<span style="text-decoration:overline">p(1&minus;p)</span> )<sup>2</sup> &nbsp;/&nbsp; ( p &minus; 0.5 )<sup>2</sup></span>
+  </div>
+  <p style="margin-top:0">
+    Everything in that fraction is mild except the denominator. The <strong>effect size</strong>
+    (p &minus; 0.5) is <em>squared</em> and sits on the bottom, so halving the bias you want to detect
+    roughly <strong>quadruples</strong> the flips you need. Set your target bias, false-alarm rate, and
+    power, and read off the budget:
+  </p>
+
+  <div class="ct-flexwrap">
+    <div class="ct-panel">
+      <div class="ct-ctrlrow">
+        <span class="nm">detect p(heads)</span>
+        <input type="range" id="ct4-p" min="51" max="80" value="55">
+        <span class="pv" id="ct4-pv">0.55</span>
+      </div>
+      <div class="ct-ctrlrow">
+        <span class="nm">&alpha; (×1000)</span>
+        <input type="range" id="ct4-a" min="1" max="200" value="50">
+        <span class="pv" id="ct4-av">0.050</span>
+      </div>
+      <div class="ct-ctrlrow">
+        <span class="nm">power (%)</span>
+        <input type="range" id="ct4-w" min="50" max="99" value="80">
+        <span class="pv" id="ct4-wv">80%</span>
+      </div>
+      <div style="margin-top:1rem">
+        <div style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;text-align:center">flips required</div>
+        <div class="ct-bignum" id="ct4-n">—</div>
+      </div>
+    </div>
+    <div class="ct-panel" style="flex:1.4">
+      <div class="se-chartwrap">
+        <svg id="ct4-svg" width="100%" height="240" viewBox="0 0 460 240"></svg>
+      </div>
+      <div class="ct-legend"><span style="color:var(--sn-accent)">required n vs bias (log scale)</span></div>
+    </div>
+  </div>
+
+  <div class="se-example" style="margin-bottom:0">
+    <strong>Worked examples (&alpha; = 0.05, power = 80%):</strong> a <strong>60/40</strong> coin
+    (p = 0.60) needs only about <strong>194</strong> flips. A <strong>55/45</strong> coin needs roughly
+    <strong>783</strong>. A <strong>51/49</strong> coin? About <strong>19,600</strong> flips — the
+    squared effect size in the denominator is merciless.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 5. SIMULATION MEETS MATH                                     -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🔬 Simulation meets math: does the formula actually hold?</h3>
+  <p style="margin-top:0">
+    A formula is only as good as its predictions. So let's <strong>brute-force it</strong>. Pick a true
+    bias, a number of flips, and &alpha;. We run a thousand independent experiments — each one flips the
+    coin n times and applies the p &lt; &alpha; test — and tally how often we correctly catch the rigged
+    coin. That <strong>empirical power</strong> should land right on the curve's <strong>predicted
+    power</strong>. Hit run and watch the two bars meet.
+  </p>
+
+  <div class="ct-flexwrap">
+    <div class="ct-panel">
+      <div class="ct-ctrlrow">
+        <span class="nm">true p(heads)</span>
+        <input type="range" id="ct5-p" min="51" max="85" value="55">
+        <span class="pv" id="ct5-pv">0.55</span>
+      </div>
+      <div class="ct-ctrlrow">
+        <span class="nm">flips n</span>
+        <input type="range" id="ct5-n" min="10" max="2000" value="783">
+        <span class="pv" id="ct5-nv">783</span>
+      </div>
+      <div class="ct-ctrlrow">
+        <span class="nm">&alpha; (×1000)</span>
+        <input type="range" id="ct5-a" min="1" max="200" value="50">
+        <span class="pv" id="ct5-av">0.050</span>
+      </div>
+      <div class="ct-controls" style="justify-content:center;margin-top:0.8rem">
+        <button class="se-btn" id="ct5-run">▶ Run 1000 experiments</button>
+        <button class="se-reset" id="ct5-reset">↺ Reset</button>
+      </div>
+    </div>
+    <div class="ct-panel" style="flex:1.3">
+      <div style="font-size:0.78rem;opacity:0.7;margin-bottom:0.3rem">progress</div>
+      <div class="ct-bar" style="margin-bottom:1rem"><div id="ct5-prog" style="width:0%;background:var(--sn-accent)"></div></div>
+
+      <div class="ct-cmprow">
+        <span class="nm">predicted</span>
+        <div class="ct-bar"><div id="ct5-tbar" style="width:0%;background:var(--sn-muted)"></div></div>
+        <span class="pv" id="ct5-tval" style="color:var(--sn-muted)">—</span>
+      </div>
+      <div class="ct-cmprow">
+        <span class="nm">simulated</span>
+        <div class="ct-bar"><div id="ct5-ebar" style="width:0%;background:var(--sn-good)"></div></div>
+        <span class="pv" id="ct5-eval" style="color:var(--sn-good)">—</span>
+      </div>
+
+      <div class="ct-statrow" style="margin-top:0.8rem">
+        <div class="ct-stat"><div class="lab">experiments</div><div class="val" id="ct5-done" style="font-size:1.3rem">0</div></div>
+        <div class="ct-stat"><div class="lab">caught</div><div class="val" id="ct5-caught" style="font-size:1.3rem;color:var(--sn-good)">0</div></div>
+      </div>
+      <div style="text-align:center;margin-top:0.3rem"><span id="ct5-tag" class="se-tag">ready</span></div>
+    </div>
+  </div>
+
+  <div class="se-note" style="margin-bottom:0">
+    <strong>Try the boundary case:</strong> with p = 0.55, n = 783, &alpha; = 0.05 the formula was tuned
+    for 80% power — so about <em>800 of the 1000</em> experiments should catch the coin, and one in five
+    should miss it even though it really is rigged. Now slide n down to 200 and watch the simulated power
+    collapse: too few flips, and the rigged coin usually escapes.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- WRAP UP                                                      -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🎁 The whole story in one breath</h3>
+  <ul style="line-height:1.7">
+    <li><strong>Assume innocence.</strong> Start from H<sub>0</sub>: "the coin is fair," and ask how
+      surprising your data would be if that were true — that's the <strong>p-value</strong>.</li>
+    <li><strong>Two errors, one tension.</strong> &alpha; controls false alarms; <strong>power</strong>
+      (1 &minus; &beta;) controls catches. You can't shrink both without more flips.</li>
+    <li><strong>One formula.</strong> n &asymp; (z<sub>&alpha;/2</sub>&radic;&frac14; +
+      z<sub>&beta;</sub>&radic;p(1&minus;p))<sup>2</sup> / (p &minus; 0.5)<sup>2</sup> turns "how sure"
+      and "how rigged" into an exact flip budget.</li>
+    <li><strong>Cost scales like 1/(p &minus; &frac12;)<sup>2</sup>.</strong> Obvious cheats are caught
+      in a few hundred flips; subtle ones can demand tens of thousands. Detecting tiny bias is
+      genuinely, quadratically expensive — and simulation confirms the math to the percent.</li>
+  </ul>
+  <p style="margin-bottom:0">
+    So next time someone insists their coin is fair, you don't have to argue — you can tell them
+    <em>exactly</em> how many flips it'll take to find out, before you throw the first one.
+  </p>
+</div>
+
+<script>
+(function () {
+  "use strict";
+  // theme-aware colors: read CSS tokens, re-read + redraw on light/dark toggle
+  const SN = document.querySelector(".study-note");
+  const readCols = () => {
+    const cs = getComputedStyle(SN);
+    const c = n => cs.getPropertyValue(n).trim();
+    return { accent: c("--sn-accent"), good: c("--sn-good"), bad: c("--sn-bad"),
+             warn: c("--sn-warn"), muted: c("--sn-muted"), grid: c("--sn-grid") };
+  };
+  let COL = readCols();
+  const redrawFns = [];
+  const onTheme = fn => { redrawFns.push(fn); return fn; };
+  new MutationObserver(() => { COL = readCols(); redrawFns.forEach(f => f()); })
+    .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+
+  // ---- math helpers (no dependencies) -------------------------------------
+  const clamp = (x, a, b) => Math.max(a, Math.min(b, x));
+  // standard normal CDF via Abramowitz & Stegun 7.1.26 erf approximation
+  function erf(x) {
+    const s = x < 0 ? -1 : 1; x = Math.abs(x);
+    const t = 1 / (1 + 0.3275911 * x);
+    const y = 1 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t * Math.exp(-x * x);
+    return s * y;
+  }
+  const Phi = z => 0.5 * (1 + erf(z / Math.SQRT2));
+  // inverse normal CDF — Peter Acklam's rational approximation
+  function zQuant(p) {
+    p = clamp(p, 1e-9, 1 - 1e-9);
+    const a = [-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02, 1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00];
+    const b = [-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02, 6.680131188771972e+01, -1.328068155288572e+01];
+    const c = [-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00, -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00];
+    const d = [7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00, 3.754408661907416e+00];
+    const pl = 0.02425, ph = 1 - pl; let q, r;
+    if (p < pl) { q = Math.sqrt(-2 * Math.log(p)); return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1); }
+    if (p <= ph) { q = p - 0.5; r = q * q; return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1); }
+    q = Math.sqrt(-2 * Math.log(1 - p)); return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1);
+  }
+  // required sample size for a two-sided test of p=0.5 vs p (power = 1-beta)
+  function requiredN(p, alpha, power) {
+    const za = zQuant(1 - alpha / 2), zb = zQuant(power);
+    const num = za * Math.sqrt(0.25) + zb * Math.sqrt(p * (1 - p));
+    return Math.ceil((num * num) / ((p - 0.5) * (p - 0.5)));
+  }
+  // power of the two-sided test at true bias p, n flips, level alpha
+  function powerAt(p, n, alpha) {
+    const za = zQuant(1 - alpha / 2);
+    const s0 = Math.sqrt(0.25 / n), s1 = Math.sqrt(p * (1 - p) / n);
+    const cHi = 0.5 + za * s0, cLo = 0.5 - za * s0;
+    return Phi((cLo - p) / s1) + (1 - Phi((cHi - p) / s1));
+  }
+
+  // ============================================================
+  // DEMO 1 — live flip simulator with shrinking fair funnel
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ct1-svg");
+    const pSlider = document.getElementById("ct1-p");
+    const pv = document.getElementById("ct1-pv");
+    const coin = document.getElementById("ct1-coin");
+    const nEl = document.getElementById("ct1-n"), hEl = document.getElementById("ct1-h"), phatEl = document.getElementById("ct1-phat");
+    const tag = document.getElementById("ct1-tag");
+
+    let heads = 0, n = 0;
+    const props = [];        // running p-hat after each flip
+    const trueP = () => pSlider.value / 100;
+
+    const W = 720, H = 260, padL = 40, padR = 14, padT = 14, padB = 26;
+    const Y = pr => padT + (1 - pr) * (H - padT - padB);
+    const X = (k, nMax) => padL + (Math.log(k) / Math.log(Math.max(nMax, 2))) * (W - padL - padR);
+    const band = k => 1.95996 * Math.sqrt(0.25 / k);   // 95% half-width for a fair coin
+
+    function flip(m) {
+      const p = trueP();
+      let last = 0;
+      for (let i = 0; i < m; i++) { last = Math.random() < p ? 1 : 0; heads += last; n++; props.push(heads / n); }
+      coin.textContent = last ? "H" : "T";
+      coin.style.color = last ? COL.accent : COL.muted;
+      coin.classList.remove("flip"); void coin.offsetWidth; coin.classList.add("flip");
+      draw();
+    }
+    function reset() { heads = 0; n = 0; props.length = 0; coin.textContent = "?"; coin.style.color = ""; draw(); }
+
+    function draw() {
+      pv.textContent = trueP().toFixed(2);
+      nEl.textContent = n; hEl.textContent = heads;
+      phatEl.textContent = n ? (heads / n).toFixed(3) : "—";
+
+      const nMax = Math.max(n, 60);
+      // gridlines + axis labels (proportion)
+      let grid = "";
+      [0, 0.25, 0.5, 0.75, 1].forEach(pr => {
+        grid += `<line x1="${padL}" y1="${Y(pr)}" x2="${W - padR}" y2="${Y(pr)}" stroke="${COL.grid}" stroke-width="1"/>`;
+        grid += `<text x="${padL - 6}" y="${Y(pr) + 3}" font-size="10" text-anchor="end">${pr.toFixed(2)}</text>`;
+      });
+      // fair funnel (95% band around 0.5), filled translucent accent
+      let up = "", lo = "";
+      const K = 160;
+      for (let i = 0; i <= K; i++) {
+        const k = Math.exp(Math.log(nMax) * i / K);   // 1 .. nMax on log scale
+        const x = X(Math.max(k, 1), nMax);
+        up += (i === 0 ? "M" : "L") + x.toFixed(1) + " " + Y(clamp(0.5 + band(k), 0, 1)).toFixed(1) + " ";
+        lo = "L" + x.toFixed(1) + " " + Y(clamp(0.5 - band(k), 0, 1)).toFixed(1) + " " + lo;
+      }
+      const funnel = `<path d="${up}${lo}Z" fill="${COL.accent}" fill-opacity="0.12" stroke="none"/>`;
+      const fair = `<line x1="${padL}" y1="${Y(0.5)}" x2="${W - padR}" y2="${Y(0.5)}" stroke="${COL.muted}" stroke-width="1.5" stroke-dasharray="5 4"/>`;
+      const trueLine = `<line x1="${padL}" y1="${Y(trueP())}" x2="${W - padR}" y2="${Y(trueP())}" stroke="${COL.good}" stroke-width="1.5" stroke-dasharray="2 3"/>`;
+
+      // running p-hat trace (subsample to keep the path light)
+      let d = "";
+      if (props.length) {
+        const step = Math.max(1, Math.floor(props.length / 600));
+        let first = true;
+        for (let k = 1; k <= props.length; k += step) {
+          const x = X(k, nMax), y = Y(props[k - 1]);
+          d += (first ? "M" : "L") + x.toFixed(1) + " " + y.toFixed(1) + " "; first = false;
+        }
+        const lx = X(props.length, nMax), ly = Y(props[props.length - 1]);
+        d += "L" + lx.toFixed(1) + " " + ly.toFixed(1) + " ";
+      }
+      const trace = d ? `<path d="${d}" fill="none" stroke="${COL.accent}" stroke-width="2"/>` : "";
+      const dot = props.length ? `<circle cx="${X(props.length, nMax).toFixed(1)}" cy="${Y(props[props.length - 1]).toFixed(1)}" r="3.5" fill="${COL.accent}"/>` : "";
+
+      svg.innerHTML = grid + funnel + fair + trueLine + trace + dot +
+        `<text x="${W - padR}" y="${Y(0.5) - 5}" font-size="10" text-anchor="end" fill="${COL.muted}">fair 0.5</text>` +
+        `<text x="${padL}" y="${H - 6}" font-size="9" opacity="0.6">flips (log scale) →</text>`;
+
+      if (!n) { tag.textContent = "flip to begin"; tag.className = "se-tag"; return; }
+      const out = Math.abs(heads / n - 0.5) > band(n);
+      if (out) { tag.textContent = "outside the fair band → looks rigged"; tag.className = "se-tag hot"; }
+      else { tag.textContent = "still consistent with fair"; tag.className = "se-tag good"; }
+    }
+
+    pSlider.addEventListener("input", draw);
+    document.getElementById("ct1-f1").addEventListener("click", () => flip(1));
+    document.getElementById("ct1-f100").addEventListener("click", () => flip(100));
+    document.getElementById("ct1-reset").addEventListener("click", reset);
+    onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 2 — null distribution and two-sided p-value
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ct2-svg");
+    const nS = document.getElementById("ct2-n"), pS = document.getElementById("ct2-p");
+    const nv = document.getElementById("ct2-nv"), pvv = document.getElementById("ct2-pv");
+    const kEl = document.getElementById("ct2-k"), zEl = document.getElementById("ct2-z"), pvalEl = document.getElementById("ct2-pval");
+    const tag = document.getElementById("ct2-tag");
+
+    const W = 720, H = 250, padL = 16, padR = 16, padT = 16, padB = 30;
+
+    function draw() {
+      const n = +nS.value, phat = pS.value / 100, k = Math.round(phat * n);
+      nv.textContent = n; pvv.textContent = phat.toFixed(2); kEl.textContent = k;
+
+      const mu = n / 2, sigma = Math.sqrt(n) / 2;
+      const z = (k - mu) / sigma;
+      const zc = Math.max(0, (Math.abs(k - mu) - 0.5) / sigma);   // continuity correction
+      const pval = clamp(2 * (1 - Phi(zc)), 0, 1);
+      zEl.textContent = z.toFixed(2);
+      pvalEl.textContent = pval < 0.001 ? pval.toExponential(1) : pval.toFixed(3);
+
+      // count-axis window around the mean
+      const loC = Math.max(0, mu - 4.2 * sigma), hiC = Math.min(n, mu + 4.2 * sigma);
+      const X = c => padL + (c - loC) / (hiC - loC) * (W - padL - padR);
+      const dens = c => Math.exp(-(c - mu) * (c - mu) / (2 * sigma * sigma));
+      const yTop = H - padB, h0 = H - padT - padB;
+      const Y = d => yTop - d * h0;
+
+      const dev = Math.abs(k - mu), loCut = mu - dev, hiCut = mu + dev;
+      const curve = (a, bb) => { let s = ""; const steps = 200; for (let i = 0; i <= steps; i++) { const c = a + (bb - a) * i / steps; s += (i === 0 ? "M" : "L") + X(c).toFixed(1) + " " + Y(dens(c)).toFixed(1) + " "; } return s; };
+
+      // shaded p-value tails (luck regions)
+      let shade = "";
+      if (dev > 0) {
+        shade += `<path d="M${X(loC).toFixed(1)} ${yTop} ${curve(loC, loCut)} L${X(loCut).toFixed(1)} ${yTop} Z" fill="${COL.bad}" fill-opacity="0.32"/>`;
+        shade += `<path d="M${X(hiCut).toFixed(1)} ${yTop} ${curve(hiCut, hiC)} L${X(hiC).toFixed(1)} ${yTop} Z" fill="${COL.bad}" fill-opacity="0.32"/>`;
+      }
+      const body = `<path d="M${X(loC).toFixed(1)} ${yTop} ${curve(loC, hiC)} L${X(hiC).toFixed(1)} ${yTop} Z" fill="${COL.accent}" fill-opacity="0.10"/>` +
+        `<path d="${curve(loC, hiC)}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>`;
+      const center = `<line x1="${X(mu)}" y1="${padT}" x2="${X(mu)}" y2="${yTop}" stroke="${COL.muted}" stroke-width="1" stroke-dasharray="4 4"/>`;
+      const marker = `<line x1="${X(k)}" y1="${Y(dens(k)) - 4}" x2="${X(k)}" y2="${yTop}" stroke="${COL.bad}" stroke-width="2"/>` +
+        `<circle cx="${X(k)}" cy="${Y(dens(k))}" r="5" fill="${COL.bad}"/>` +
+        `<text x="${clamp(X(k), padL + 30, W - padR - 30)}" y="${padT + 12}" font-size="11" text-anchor="middle" fill="${COL.bad}" font-weight="700">observed: ${k}</text>`;
+      // axis ticks (as proportions for intuition)
+      let ax = "";
+      [0.25, 0.5, 0.75].forEach(pr => { const c = pr * n; if (c >= loC && c <= hiC) ax += `<text x="${X(c)}" y="${H - 8}" font-size="10" text-anchor="middle">${pr}</text>`; });
+
+      svg.innerHTML = shade + body + center + marker + ax +
+        `<text x="${X(mu)}" y="${yTop + 14}" font-size="10" text-anchor="middle" fill="${COL.muted}">heads as a fraction of n</text>`;
+
+      if (pval < 0.05) { tag.textContent = "p < 0.05 → reject fair (rigged)"; tag.className = "se-tag hot"; }
+      else if (pval < 0.1) { tag.textContent = "borderline — suggestive, not proof"; tag.className = "se-tag warn"; }
+      else { tag.textContent = "consistent with a fair coin"; tag.className = "se-tag good"; }
+    }
+    nS.addEventListener("input", draw); pS.addEventListener("input", draw);
+    onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 3 — alpha vs power: two overlapping distributions
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ct3-svg");
+    const pS = document.getElementById("ct3-p"), nS = document.getElementById("ct3-n"), aS = document.getElementById("ct3-a");
+    const pvv = document.getElementById("ct3-pv"), nvv = document.getElementById("ct3-nv"), avv = document.getElementById("ct3-av");
+    const powEl = document.getElementById("ct3-pow"), a2El = document.getElementById("ct3-a2"), tag = document.getElementById("ct3-tag");
+
+    const W = 720, H = 260, padL = 16, padR = 16, padT = 18, padB = 30;
+
+    function draw() {
+      const p = pS.value / 100, n = +nS.value, alpha = aS.value / 1000;
+      pvv.textContent = p.toFixed(2); nvv.textContent = n; avv.textContent = alpha.toFixed(3);
+
+      const s0 = Math.sqrt(0.25 / n), s1 = Math.sqrt(p * (1 - p) / n);
+      const za = zQuant(1 - alpha / 2);
+      const cHi = 0.5 + za * s0, cLo = 0.5 - za * s0;
+      const power = powerAt(p, n, alpha);
+      powEl.textContent = (power * 100).toFixed(1) + "%";
+      a2El.textContent = (alpha * 100).toFixed(1) + "%";
+
+      // shared p-hat window
+      const lo = Math.min(0.5 - 4.2 * s0, p - 4.2 * s1);
+      const hi = Math.max(0.5 + 4.2 * s0, p + 4.2 * s1);
+      const X = v => padL + (v - lo) / (hi - lo) * (W - padL - padR);
+      const yTop = H - padB, h0 = H - padT - padB;
+      // densities normalised so the TALLER (null, smaller sigma) peaks near the top
+      const peak0 = 1, peak1 = s0 / s1;   // relative heights (1/sigma)
+      const g = (v, mu, s, pk) => pk * Math.exp(-(v - mu) * (v - mu) / (2 * s * s));
+      const Y = d => yTop - d * h0 / Math.max(peak0, peak1);
+
+      const curve = (mu, s, pk) => { let str = ""; const steps = 220; for (let i = 0; i <= steps; i++) { const v = lo + (hi - lo) * i / steps; str += (i === 0 ? "M" : "L") + X(v).toFixed(1) + " " + Y(g(v, mu, s, pk)).toFixed(1) + " "; } return str; };
+      const fillUnder = (mu, s, pk, a, b, col, op) => { let str = `M${X(a).toFixed(1)} ${yTop} `; const steps = 120; for (let i = 0; i <= steps; i++) { const v = a + (b - a) * i / steps; str += "L" + X(v).toFixed(1) + " " + Y(g(v, mu, s, pk)).toFixed(1) + " "; } str += `L${X(b).toFixed(1)} ${yTop} Z`; return `<path d="${str}" fill="${col}" fill-opacity="${op}"/>`; };
+
+      // power region (alt curve beyond critical lines) — green
+      let shade = fillUnder(p, s1, peak1, cHi, hi, COL.good, 0.30);
+      shade += fillUnder(p, s1, peak1, lo, cLo, COL.good, 0.30);
+      // alpha region (null curve beyond critical lines) — red
+      shade += fillUnder(0.5, s0, peak0, cHi, hi, COL.bad, 0.40);
+      shade += fillUnder(0.5, s0, peak0, lo, cLo, COL.bad, 0.40);
+
+      const curves =
+        `<path d="${curve(p, s1, peak1)}" fill="none" stroke="${COL.good}" stroke-width="2.5"/>` +
+        `<path d="${curve(0.5, s0, peak0)}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>`;
+      const crit = [cLo, cHi].map(c => (c > lo && c < hi)
+        ? `<line x1="${X(c)}" y1="${padT}" x2="${X(c)}" y2="${yTop}" stroke="${COL.muted}" stroke-width="1.5" stroke-dasharray="4 3"/>` : "").join("");
+      // axis ticks
+      let ax = "";
+      [0.4, 0.5, 0.6, 0.7, 0.8].forEach(t => { if (t > lo && t < hi) ax += `<text x="${X(t)}" y="${H - 8}" font-size="10" text-anchor="middle">${t}</text>`; });
+
+      svg.innerHTML = shade + curves + crit + ax +
+        `<text x="${X(0.5)}" y="${padT - 4}" font-size="10" text-anchor="middle" fill="${COL.accent}">fair</text>` +
+        `<text x="${clamp(X(p), padL + 14, W - padR - 14)}" y="${padT - 4}" font-size="10" text-anchor="middle" fill="${COL.good}">true</text>`;
+
+      if (power >= 0.8) { tag.textContent = "power ≥ 80% — reliable catch"; tag.className = "se-tag good"; }
+      else if (power >= 0.5) { tag.textContent = "coin-flip odds of catching it"; tag.className = "se-tag warn"; }
+      else { tag.textContent = "underpowered — it usually escapes"; tag.className = "se-tag hot"; }
+    }
+    [pS, nS, aS].forEach(s => s.addEventListener("input", draw));
+    onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 4 — sample-size calculator + cost-vs-bias curve
+  // ============================================================
+  (function () {
+    const svg = document.getElementById("ct4-svg");
+    const pS = document.getElementById("ct4-p"), aS = document.getElementById("ct4-a"), wS = document.getElementById("ct4-w");
+    const pvv = document.getElementById("ct4-pv"), avv = document.getElementById("ct4-av"), wvv = document.getElementById("ct4-wv");
+    const nEl = document.getElementById("ct4-n");
+
+    const W = 460, H = 240, padL = 50, padR = 16, padT = 16, padB = 36;
+
+    function draw() {
+      const p = pS.value / 100, alpha = aS.value / 1000, power = wS.value / 100;
+      pvv.textContent = p.toFixed(2); avv.textContent = alpha.toFixed(3); wvv.textContent = (power * 100).toFixed(0) + "%";
+      const nNow = requiredN(p, alpha, power);
+      nEl.textContent = nNow.toLocaleString();
+
+      // curve: required n across detectable biases, fixed alpha/power, log-y
+      const pLo = 0.51, pHi = 0.80;
+      const X = pp => padL + (pp - pLo) / (pHi - pLo) * (W - padL - padR);
+      const yMaxLog = Math.log10(requiredN(pLo, alpha, power));
+      const yMinLog = Math.log10(Math.max(2, requiredN(pHi, alpha, power)));
+      const Y = nn => { const l = clamp(Math.log10(nn), yMinLog, yMaxLog); return H - padB - (l - yMinLog) / (yMaxLog - yMinLog) * (H - padT - padB); };
+
+      let grid = "";
+      // log gridlines at powers of ten
+      for (let e = Math.floor(yMinLog); e <= Math.ceil(yMaxLog); e++) {
+        const val = Math.pow(10, e); if (Math.log10(val) < yMinLog - 0.01 || Math.log10(val) > yMaxLog + 0.01) continue;
+        grid += `<line x1="${padL}" y1="${Y(val)}" x2="${W - padR}" y2="${Y(val)}" stroke="${COL.grid}" stroke-width="1"/>`;
+        grid += `<text x="${padL - 6}" y="${Y(val) + 3}" font-size="9" text-anchor="end">${val >= 1000 ? (val / 1000) + "k" : val}</text>`;
+      }
+      [0.55, 0.6, 0.65, 0.7, 0.75].forEach(t => { grid += `<text x="${X(t)}" y="${H - padB + 16}" font-size="9" text-anchor="middle">${t}</text>`; });
+
+      let d = ""; const steps = 120;
+      for (let i = 0; i <= steps; i++) { const pp = pLo + (pHi - pLo) * i / steps; d += (i === 0 ? "M" : "L") + X(pp).toFixed(1) + " " + Y(requiredN(pp, alpha, power)).toFixed(1) + " "; }
+      const marker = (p >= pLo && p <= pHi)
+        ? `<line x1="${X(p)}" y1="${Y(nNow)}" x2="${X(p)}" y2="${H - padB}" stroke="${COL.bad}" stroke-width="1.5" stroke-dasharray="3 3"/>` +
+          `<circle cx="${X(p)}" cy="${Y(nNow)}" r="5" fill="${COL.bad}"/>` +
+          `<text x="${clamp(X(p) + 8, padL, W - padR - 70)}" y="${clamp(Y(nNow) - 6, padT + 10, H - padB)}" font-size="11" fill="${COL.bad}" font-weight="700">${nNow.toLocaleString()}</text>`
+        : "";
+
+      svg.innerHTML = grid +
+        `<path d="${d}" fill="none" stroke="${COL.accent}" stroke-width="2.5"/>` + marker +
+        `<text x="${X((pLo + pHi) / 2)}" y="${H - 4}" font-size="11" text-anchor="middle">coin's true bias  p(heads)</text>` +
+        `<text x="14" y="${padT + 84}" font-size="11" transform="rotate(-90 14 ${padT + 84})" text-anchor="middle">flips needed (log)</text>`;
+    }
+    [pS, aS, wS].forEach(s => s.addEventListener("input", draw));
+    onTheme(draw); draw();
+  })();
+
+  // ============================================================
+  // DEMO 5 — Monte-Carlo power check (simulation vs formula)
+  // ============================================================
+  (function () {
+    const pS = document.getElementById("ct5-p"), nS = document.getElementById("ct5-n"), aS = document.getElementById("ct5-a");
+    const pvv = document.getElementById("ct5-pv"), nvv = document.getElementById("ct5-nv"), avv = document.getElementById("ct5-av");
+    const prog = document.getElementById("ct5-prog"), tbar = document.getElementById("ct5-tbar"), ebar = document.getElementById("ct5-ebar");
+    const tval = document.getElementById("ct5-tval"), eval_ = document.getElementById("ct5-eval");
+    const doneEl = document.getElementById("ct5-done"), caughtEl = document.getElementById("ct5-caught"), tag = document.getElementById("ct5-tag");
+    const runBtn = document.getElementById("ct5-run");
+    const TOTAL = 1000;
+
+    let done = 0, caught = 0, running = false, raf = null;
+
+    function theoryPower() { return powerAt(nS.value / 100, +nS.value, aS.value / 1000); }
+    function reflectLabels() { pvv.textContent = (pS.value / 100).toFixed(2); nvv.textContent = nS.value; avv.textContent = (aS.value / 1000).toFixed(3); }
+
+    function showTheory() {
+      const t = theoryPower();
+      tbar.style.width = (t * 100).toFixed(1) + "%"; tval.textContent = (t * 100).toFixed(1) + "%";
+    }
+    function reset() {
+      stop(); done = 0; caught = 0;
+      prog.style.width = "0%"; ebar.style.width = "0%"; eval_.textContent = "—";
+      doneEl.textContent = "0"; caughtEl.textContent = "0"; tag.textContent = "ready"; tag.className = "se-tag";
+      reflectLabels(); showTheory();
+    }
+    // one experiment: n flips at true p, reject if |k - n/2| beyond the critical deviation
+    function oneExperiment(p, n, kc) {
+      let k = 0; for (let i = 0; i < n; i++) if (Math.random() < p) k++;
+      return Math.abs(k - n / 2) > kc;
+    }
+    function update() {
+      prog.style.width = (done / TOTAL * 100).toFixed(1) + "%";
+      doneEl.textContent = done; caughtEl.textContent = caught;
+      const emp = done ? caught / done : 0;
+      ebar.style.width = (emp * 100).toFixed(1) + "%";
+      eval_.textContent = done ? (emp * 100).toFixed(1) + "%" : "—";
+    }
+    function loop() {
+      if (!running) return;
+      const p = pS.value / 100, n = +nS.value, alpha = aS.value / 1000;
+      const kc = zQuant(1 - alpha / 2) * Math.sqrt(n) / 2;
+      const batch = Math.min(25, TOTAL - done);
+      for (let i = 0; i < batch; i++) { if (oneExperiment(p, n, kc)) caught++; done++; }
+      update();
+      if (done >= TOTAL) { finish(); return; }
+      raf = requestAnimationFrame(loop);
+    }
+    function finish() {
+      stop();
+      const emp = caught / TOTAL, t = theoryPower();
+      const diff = Math.abs(emp - t);
+      tag.textContent = "simulated " + (emp * 100).toFixed(1) + "% vs predicted " + (t * 100).toFixed(1) + "%";
+      tag.className = diff < 0.05 ? "se-tag good" : "se-tag warn";
+    }
+    function start() {
+      if (done >= TOTAL) reset();
+      running = true; runBtn.textContent = "⏳ Running…"; runBtn.disabled = true;
+      showTheory(); raf = requestAnimationFrame(loop);
+    }
+    function stop() { running = false; runBtn.textContent = "▶ Run 1000 experiments"; runBtn.disabled = false; if (raf) cancelAnimationFrame(raf); }
+
+    [pS, nS, aS].forEach(s => s.addEventListener("input", () => { reset(); }));
+    runBtn.addEventListener("click", start);
+    document.getElementById("ct5-reset").addEventListener("click", reset);
+    onTheme(() => { showTheory(); });   // theory bar color/labels survive theme toggle
+    reset();
+  })();
+})();
+</script>
+
+</div>


### PR DESCRIPTION
A new interactive study note answering "how many flips to detect a
rigged coin?" with both simulation and pure math (frequentist).

Five vanilla-JS/SVG demos following the shared study-note design
system (ct- prefix, theme-aware tokens):
- live flip simulator with a shrinking 95% fair funnel
- null distribution + two-sided p-value
- alpha vs power as two overlapping distributions
- sample-size calculator with a 1/(p-0.5)^2 cost curve
- Monte-Carlo power check (simulation vs the formula)

Math helpers (normal CDF, inverse-normal quantile, sample-size and
power formulas) are inline with no dependencies; cited worked
examples (n ~= 194/783/19,600) verified against the code.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0184pEyvKjDbDNyaRhTo1TPp