### PR TITLE
Add GoatCounter analytics

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,6 +32,8 @@ footer-links:
   googleplus: # anything in your profile username that comes after plus.google.com/
 
 
+goatcounter: https://alexdruso.goatcounter.com/count
+
 # Your website URL
 # Used for Sitemap.xml and your RSS feed
 url: https://alexdruso.github.io

--- a/docs/_includes/analytics.html
+++ b/docs/_includes/analytics.html
@@ -1,16 +1,4 @@
-{% if site.google_analytics %}
-	<!-- Google Analytics -->
-	<script>
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-		ga('create', '{{ site.google_analytics }}', 'auto');
-		ga('send', 'pageview', {
-		  'page': '{{ site.baseurl }}{{ page.url }}',
-		  'title': '{{ page.title | replace: "'", "\\'" }}'
-		});
-	</script>
-	<!-- End Google Analytics -->
+{% if site.goatcounter %}
+<script data-goatcounter="{{ site.goatcounter }}"
+        async src="//gc.zgo.at/count.js"></script>
 {% endif %}


### PR DESCRIPTION
## Summary

- Replaces the dead Universal Analytics (UA) snippet with [GoatCounter](https://www.goatcounter.com) — lightweight, cookie-free, no consent banner needed
- Stores the GoatCounter endpoint in `docs/_config.yml` under `goatcounter:` so it can be disabled locally by removing the key
- `analytics.html` is already included in `_layouts/default.html` and guarded by `{% if site.goatcounter %}`, so no layout changes needed

## Test plan

- [ ] Merge the domain/cleanup PR first (`claude/repo-cleanup-domain-migration-u2ilma`) so `docs/_config.yml` has no conflicts
- [ ] After deploy, open the site and verify no `analytics.js` (old UA) loads in the network tab
- [ ] Verify `gc.zgo.at/count.js` loads and a pageview appears in the GoatCounter dashboard at `alexdruso.goatcounter.com`

---
_Generated by [Claude Code](https://claude.ai/code/session_013UjxNryqJHHAMySkLUoNWE)_