### PR TITLE
Add touch controls to Snake game for mobile play

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -6,7 +6,7 @@ permalink: /game/
 
 <div class="game-container">
   <h1>Snake Game</h1>
-  <p class="game-description">Take a break and play a classic game of Snake! Use arrow keys to control the snake and eat the food to grow longer.</p>
+  <p class="game-description">Take a break and play a classic game of Snake! On desktop use the arrow keys; on a phone, swipe on the board or use the on-screen pad below. Eat the food to grow longer.</p>
   
   <div class="game-wrapper">
     <canvas id="gameCanvas" width="400" height="400"></canvas>
@@ -14,6 +14,13 @@ permalink: /game/
       <div class="score">Score: <span id="score">0</span></div>
       <button id="startButton">Start Game</button>
       <button id="resetButton">Reset Game</button>
+    </div>
+
+    <div class="dpad" id="dpad" aria-label="Directional controls">
+      <button class="dpad-btn dpad-up" data-dir="up" aria-label="Move up">&#9650;</button>
+      <button class="dpad-btn dpad-left" data-dir="left" aria-label="Move left">&#9664;</button>
+      <button class="dpad-btn dpad-right" data-dir="right" aria-label="Move right">&#9654;</button>
+      <button class="dpad-btn dpad-down" data-dir="down" aria-label="Move down">&#9660;</button>
     </div>
   </div>
 </div>
@@ -33,6 +40,7 @@ let nextDirection = 'right';
 let gameInterval;
 let score = 0;
 let gameStarted = false;
+let listenersBound = false;
 
 // Initialize game
 function initGame() {
@@ -58,18 +66,34 @@ function initGame() {
   // Initialize food
   generateFood();
   
-  // Set up event listeners
-  document.addEventListener('keydown', handleKeyPress);
-  
-  const startButton = document.getElementById('startButton');
-  const resetButton = document.getElementById('resetButton');
-  
-  if (startButton) {
-    startButton.addEventListener('click', startGame);
-  }
-  
-  if (resetButton) {
-    resetButton.addEventListener('click', resetGame);
+  // Set up event listeners once (initGame also runs on reset)
+  if (!listenersBound) {
+    document.addEventListener('keydown', handleKeyPress);
+
+    canvas.addEventListener('touchstart', handleTouchStart, {passive: false});
+    canvas.addEventListener('touchmove', handleTouchMove, {passive: false});
+    canvas.addEventListener('touchend', handleTouchEnd, {passive: false});
+
+    // On-screen directional pad (taps and presses)
+    document.querySelectorAll('.dpad-btn').forEach(btn => {
+      const dir = btn.getAttribute('data-dir');
+      const press = (e) => { e.preventDefault(); setDirection(dir); };
+      btn.addEventListener('click', press);
+      btn.addEventListener('touchstart', press, {passive: false});
+    });
+
+    const startButton = document.getElementById('startButton');
+    const resetButton = document.getElementById('resetButton');
+
+    if (startButton) {
+      startButton.addEventListener('click', startGame);
+    }
+
+    if (resetButton) {
+      resetButton.addEventListener('click', resetGame);
+    }
+
+    listenersBound = true;
   }
   
   // Draw initial state
@@ -92,24 +116,78 @@ function generateFood() {
   }
 }
 
+// Opposite directions can't be entered (no 180° turns)
+const OPPOSITE = {up: 'down', down: 'up', left: 'right', right: 'left'};
+
+// Apply a direction change from any input source (keyboard, swipe, d-pad)
+function setDirection(dir) {
+  if (!gameStarted) return;
+  if (OPPOSITE[dir] !== direction) {
+    nextDirection = dir;
+  }
+}
+
 // Handle keyboard input
 function handleKeyPress(e) {
   if (!gameStarted) return;
   
   switch(e.key) {
     case 'ArrowUp':
-      if (direction !== 'down') nextDirection = 'up';
+      setDirection('up');
+      e.preventDefault();
       break;
     case 'ArrowDown':
-      if (direction !== 'up') nextDirection = 'down';
+      setDirection('down');
+      e.preventDefault();
       break;
     case 'ArrowLeft':
-      if (direction !== 'right') nextDirection = 'left';
+      setDirection('left');
+      e.preventDefault();
       break;
     case 'ArrowRight':
-      if (direction !== 'left') nextDirection = 'right';
+      setDirection('right');
+      e.preventDefault();
       break;
   }
+}
+
+// Handle swipe gestures on the canvas (touch devices)
+let touchStartX = 0;
+let touchStartY = 0;
+let touchActive = false;
+
+function handleTouchStart(e) {
+  const t = e.changedTouches[0];
+  touchStartX = t.clientX;
+  touchStartY = t.clientY;
+  touchActive = true;
+  // Prevent the page from scrolling while swiping on the board
+  e.preventDefault();
+}
+
+function handleTouchMove(e) {
+  if (touchActive) e.preventDefault();
+}
+
+function handleTouchEnd(e) {
+  if (!touchActive) return;
+  touchActive = false;
+
+  const t = e.changedTouches[0];
+  const dx = t.clientX - touchStartX;
+  const dy = t.clientY - touchStartY;
+  const absX = Math.abs(dx);
+  const absY = Math.abs(dy);
+
+  // Ignore tiny movements (treat as a tap, not a swipe)
+  if (Math.max(absX, absY) < 20) return;
+
+  if (absX > absY) {
+    setDirection(dx > 0 ? 'right' : 'left');
+  } else {
+    setDirection(dy > 0 ? 'down' : 'up');
+  }
+  e.preventDefault();
 }
 
 // Move snake

--- a/docs/style.scss
+++ b/docs/style.scss
@@ -858,6 +858,51 @@ footer {
   border-radius: 8px;
   background-color: $white;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  // Let the game handle swipes instead of the browser scrolling/zooming
+  touch-action: none;
+}
+
+// On-screen directional pad — hidden on desktop, shown on touch devices
+.dpad {
+  display: none;
+  grid-template-columns: repeat(3, 56px);
+  grid-template-rows: repeat(3, 56px);
+  gap: 0.4rem;
+  margin-top: 1rem;
+  justify-content: center;
+}
+
+.dpad-btn {
+  font-size: 1.3rem;
+  line-height: 1;
+  border: none;
+  border-radius: 8px;
+  background-color: $lightBlue;
+  color: $darkGray;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dpad-btn:active {
+  background-color: $accentBlue;
+  color: $white;
+}
+
+.dpad-up    { grid-column: 2; grid-row: 1; }
+.dpad-left  { grid-column: 1; grid-row: 2; }
+.dpad-right { grid-column: 3; grid-row: 2; }
+.dpad-down  { grid-column: 2; grid-row: 3; }
+
+// Show the pad on touch-primary devices
+@media (hover: none) and (pointer: coarse) {
+  .dpad {
+    display: grid;
+  }
 }
 
 .game-controls {
@@ -921,6 +966,16 @@ footer {
   #resetButton {
     background-color: $dark-border;
     color: $dark-text;
+  }
+
+  .dpad-btn {
+    background-color: $dark-border;
+    color: $dark-text;
+
+    &:active {
+      background-color: $dark-accent;
+      color: $white;
+    }
   }
 }
 


### PR DESCRIPTION
The game previously only responded to arrow keys, making it
unplayable on phones. Add two touch input methods:

- Swipe gestures on the canvas (with touch-action: none so swipes
  don't scroll the page)
- An on-screen directional pad, shown only on touch-primary devices

Refactor direction changes into a shared setDirection() helper used
by keyboard, swipe, and d-pad inputs, and guard listener binding so
it only happens once across resets.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JpJgPcz63VKmeYHNWzaaAF