### PR TITLE
Add jekyll-sitemap gem to Gemfile

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -7,6 +7,7 @@ gem "webrick", "~> 1.8"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-sitemap"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
The plugin was listed in _config.yml but missing from the Gemfile,
causing the Jekyll build to fail with a dependency error.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014u9Z1cZ7Ss1dSGR9BDZ8Jw