### PR TITLE
Fix inaccuracies and bugs in study notes

### DIFF
--- a/docs/_posts/2026-05-21-finding-optimal-policies-mdp.html
+++ b/docs/_posts/2026-05-21-finding-optimal-policies-mdp.html
@@ -257,11 +257,11 @@ excerpt: "A Markov Decision Process models sequential decisions under uncertaint
   <div class="example-box">
     <strong>Iteration 1</strong> (V = 0 everywhere): Q(Balanced, 📚 Study) = 5 + 0 = <strong>5</strong>, Q(Balanced, 🎮 Play) = 7 + 0 = <strong>7</strong>, Q(Balanced, 💤 Rest) = 3 + 0 = <strong>3</strong>. Play wins on pure immediate reward.
     <br><br>
-    <strong>After convergence</strong> (V approximately [70, 80, 94, 106, 113]):
+    <strong>After convergence</strong> (V approximately [74, 84, 96, 107, 114]):
     <br>
-    Q(Balanced, 📚 Study) = 5 + 0.9&times;(0.1&times;80 + 0.3&times;94 + 0.6&times;106) = 5 + 89.8 = <strong>94.8 ← winner</strong><br>
-    Q(Balanced, 🎮 Play)&nbsp; = 7 + 0.9&times;(0.4&times;80 + 0.4&times;94 + 0.2&times;106) = 7 + 81.7 = <strong>88.7</strong><br>
-    Q(Balanced, 💤 Rest)&nbsp; = 3 + 0.9&times;(0.5&times;94 + 0.4&times;106 + 0.1&times;113) = 3 + 90.6 = <strong>93.6</strong>
+    Q(Balanced, 📚 Study) = 5 + 0.9&times;(0.1&times;84 + 0.3&times;96 + 0.6&times;107) = 5 + 91.5 = <strong>96.5 ← winner</strong><br>
+    Q(Balanced, 🎮 Play)&nbsp; = 7 + 0.9&times;(0.4&times;84 + 0.4&times;96 + 0.2&times;107) = 7 + 84.4 = <strong>91.4</strong><br>
+    Q(Balanced, 💤 Rest)&nbsp; = 3 + 0.9&times;(0.5&times;96 + 0.4&times;107 + 0.1&times;114) = 3 + 92.2 = <strong>95.2</strong>
     <br><br>
     Play's +2 immediate lead is overwhelmed because Study transitions toward Focused and Star — states where the daily reward is 10–14, not 7. The long-term math is decisive.
   </div>

--- a/docs/_posts/2026-05-30-boltzmann-machines-visually.html
+++ b/docs/_posts/2026-05-30-boltzmann-machines-visually.html
@@ -221,7 +221,7 @@ excerpt: "Hopfield networks slide downhill into the nearest memory — and get s
   </div>
   <div class="bm-legend">
     <span style="color:var(--sn-accent)">low energy (likely)</span>
-    <span style="color:var(--sn-bad)">high energy (rare)</span>
+    <span style="color:var(--sn-muted)">high energy (rare)</span>
   </div>
 
   <div class="bm-flexwrap" style="margin-top:1rem">

--- a/docs/_posts/2026-06-16-shannon-entropy-visually.html
+++ b/docs/_posts/2026-06-16-shannon-entropy-visually.html
@@ -342,7 +342,7 @@ excerpt: "Entropy is usually introduced as a formula — −Σ p log p — with 
         `<text x="13" y="${padT + 84}" font-size="11" transform="rotate(-90 13 ${padT + 84})" text-anchor="middle">surprise (bits)</text>`;
 
       if (p > 0.9) msg.innerHTML = "Almost certain — barely any surprise. A forecast like this tells you next to nothing.";
-      else if (p > 0.45 && p < 0.55) msg.innerHTML = "A coin-flip outcome: <strong>exactly 1 bit</strong> of surprise.";
+      else if (p > 0.49 && p < 0.51) msg.innerHTML = "A coin-flip outcome (p = 1/2): <strong>exactly 1 bit</strong> of surprise.";
       else if (p < 0.05) msg.innerHTML = "Rare and shocking — many bits. It'd take this many yes/no questions to single it out.";
       else msg.innerHTML = "Halve the probability and the surprise goes up by exactly one bit.";
     }

--- a/docs/_posts/2026-06-19-how-many-tosses-rigged-coin.html
+++ b/docs/_posts/2026-06-19-how-many-tosses-rigged-coin.html
@@ -720,7 +720,7 @@ excerpt: "How many flips does it take to confidently tell a rigged coin from a f
 
     let done = 0, caught = 0, running = false, raf = null;
 
-    function theoryPower() { return powerAt(nS.value / 100, +nS.value, aS.value / 1000); }
+    function theoryPower() { return powerAt(pS.value / 100, +nS.value, aS.value / 1000); }
     function reflectLabels() { pvv.textContent = (pS.value / 100).toFixed(2); nvv.textContent = nS.value; avv.textContent = (aS.value / 1000).toFixed(3); }
 
     function showTheory() {

--- a/docs/_posts/2026-06-19-options-theory-visually.html
+++ b/docs/_posts/2026-06-19-options-theory-visually.html
@@ -588,9 +588,13 @@ excerpt: "The Black–Scholes formula — N(d₁), N(d₂) — is easy to memori
       const mu = Math.log(S0) + (r - 0.5 * sig * sig) * T;       // lognormal params of S_T
       const dens = x => x <= 0 ? 0 : Math.exp(-Math.pow(Math.log(x) - mu, 2) / (2 * vt * vt)) / (x * vt * SQRT2PI);
 
-      // numeric discounted E[payoff]
-      let acc = 0; const dx = 0.5;
-      for (let x = dx / 2; x < 600; x += dx) acc += Math.max(x - K, 0) * dens(x) * dx;
+      // numeric discounted E[payoff] — integrate over a domain that tracks the
+      // lognormal (6 sigma above E[log S_T]) so the heavy right tail is captured
+      // at high vol, with a fixed sample count to keep redraw cost constant
+      let acc = 0; const N = 2000;
+      const upper = Math.exp(mu + 6 * vt);
+      const dx = upper / N;
+      for (let i = 0; i < N; i++) { const x = (i + 0.5) * dx; acc += Math.max(x - K, 0) * dens(x) * dx; }
       const numV = Math.exp(-r * T) * acc;
       numEl.textContent = numV.toFixed(2);
       bsEl.textContent = bs(S0, K, r, sig, T, "call").price.toFixed(2);

--- a/docs/_posts/2026-06-22-temperature-and-entropy-llms.html
+++ b/docs/_posts/2026-06-22-temperature-and-entropy-llms.html
@@ -183,7 +183,7 @@ excerpt: "The temperature parameter in an LLM divides the logits before the soft
     temperature and watch the three quantities trade off. <em>(Units: <strong>&lang;E&rang;</strong> and
     <strong>F</strong> are in <strong>logit</strong> (score) units — energy is just −logit — while
     <strong>S</strong> is in <strong>nats</strong> (natural log, where <em>F = −T&nbsp;ln&nbsp;Z</em>
-    holds exactly; nats are bits &times; ln&nbsp;2). The factor <em>T</em> in <em>T&middot;S</em> is what
+    holds exactly; entropy in nats = entropy in bits &times; ln&nbsp;2, so 1&nbsp;nat &asymp; 1.44&nbsp;bits). The factor <em>T</em> in <em>T&middot;S</em> is what
     converts nats into the same logit units, so the subtraction is well-posed.)</em>
   </p>
 


### PR DESCRIPTION
Audited all six interactive study notes for factual/mathematical errors
and code bugs, then verified each finding before fixing:

- MDP: corrected the "after convergence" value vector and worked Q-value
  arithmetic ([70,80,94,106,113] → [74,84,96,107,114]) to match the values
  the embedded value-iteration demo actually produces.
- Rigged coin: theoryPower() passed the flips slider (nS) as the bias p,
  giving p>1 → sqrt of a negative → NaN in the predicted-power bar. Use the
  bias slider pS instead so the predicted bar matches the simulation.
- Options: the numeric E[payoff] integral was truncated at a fixed x<600,
  undershooting Black–Scholes by up to ~16% at high vol where the lognormal
  tail extends past 600. Integrate over a distribution-scaled domain
  (6σ above E[log S_T]) with a fixed sample count so it converges onto the
  closed form without blowing up per-redraw cost.
- Boltzmann: DEMO C legend swatch for "high energy" used --sn-bad (red) but
  the bars interpolate toward --sn-muted; aligned the swatch to --sn-muted.
- Shannon entropy: "exactly 1 bit" message fired across p∈(0.45,0.55) where
  single-outcome surprise −log2 p ranges 0.86–1.15 bits; tightened to p≈0.5.
- Temperature/entropy: "nats are bits × ln 2" read as a unit identity
  (backwards); reworded as an entropy-value conversion (1 nat ≈ 1.44 bits).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MHHjQGmN3Rm3rG8XgD1R7j