### PR TITLE
Tighten Forward-Forward scorecard with exact paper figures

### DIFF
--- a/docs/_posts/2026-07-05-forward-forward-algorithm.html
+++ b/docs/_posts/2026-07-05-forward-forward-algorithm.html
@@ -387,12 +387,12 @@ excerpt: "Hinton's Forward-Forward algorithm trains a network without backpropag
     <tr>
       <td>Empirical results</td>
       <td>State of the art everywhere it's been tried at scale</td>
-      <td>~1.4% MNIST test error with small fully-connected nets — comparable to an equivalent backprop MLP; somewhat behind on CIFAR-10; unproven at scale</td>
+      <td>1.36% MNIST test error (4 hidden layers of 2000 ReLUs, 60 epochs) — comparable to a ~1.4% backprop MLP baseline; slightly behind on CIFAR-10 (≈41% vs ≈37% test error); unproven at scale</td>
     </tr>
     <tr>
       <td>Speed</td>
-      <td>Faster per example (one pass each way, exact gradients)</td>
-      <td>Somewhat slower, and generalizes slightly worse on several of the toy problems tested</td>
+      <td>Faster (reaches FF's MNIST accuracy in ~20 epochs)</td>
+      <td>Somewhat slower (~60 epochs for the MNIST result), and generalizes slightly worse on several of the toy problems tested</td>
     </tr>
   </table>
   </div>


### PR DESCRIPTION
Follow-up to #34. The deep-research fact-check of the Forward-Forward note completed after the merge: all 12 claims verified 3–0 against the primary source (arXiv:2212.13345). The note was factually sound; this PR just replaces the two approximate figures in the scorecard with the exact verified ones:

- **Empirical results**: "~1.4% MNIST test error" → **1.36%** test error (4 hidden layers of 2000 ReLUs, 60 epochs) vs a ~1.4% backprop MLP baseline, plus the concrete CIFAR-10 gap (≈41% vs ≈37% test error).
- **Speed**: adds the paper's concrete figure — backprop reaches similar MNIST performance in ~20 epochs vs FF's 60.

Verified by rebuilding the site and re-screenshotting the note in light and dark; the scorecard renders cleanly and nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCDvxNTud5PcAVBZn4s8UD

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCDvxNTud5PcAVBZn4s8UD)_