### PR TITLE
Add study note: implicit neural representations with live in-browser training

### DIFF
--- a/docs/_posts/2026-07-08-implicit-neural-representations.html
+++ b/docs/_posts/2026-07-08-implicit-neural-representations.html
@@ -1,0 +1,1051 @@
+---
+layout: post
+title: "Implicit Neural Representations: When the Network Is the Image"
+date: 2026-07-08
+categories: [Machine Learning, Interactive]
+excerpt: "An implicit neural representation stores a signal as a function: a small network maps continuous (x, y) coordinates to RGB, so the image lives in the weights instead of a pixel grid. Why a plain ReLU MLP can only learn a blurry version (spectral bias), how Fourier features and SIREN's sine activations fix it, and what the functional view buys — rendering one trained network at any resolution, including scales it never saw. With live in-browser training."
+---
+
+{% include study-note-styles.html %}
+
+<div class="study-note">
+
+<style>
+/* Note-specific LAYOUT only. Colors come from --sn-* tokens; shared
+   components (sections, buttons, sliders, tags, equations, notes, charts)
+   live in _includes/study-note-styles.html. */
+/* the site-wide Meyer reset flattens sub/sup; restore them for the equations */
+.study-note sub, .study-note sup { font-size: 0.72em; line-height: 0; }
+.study-note sub { vertical-align: sub; }
+.study-note sup { vertical-align: super; }
+
+.inr-controls { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
+.inr-flexwrap { display: flex; gap: 1rem; flex-wrap: wrap; align-items: flex-start; justify-content: center; }
+.inr-readout { font-family: var(--sn-mono); font-variant-numeric: tabular-nums; font-weight: 600; color: var(--sn-accent); }
+
+.inr-panel { text-align: center; }
+.inr-panel h4 { margin: 0 0 0.35rem; font-size: 0.82rem; }
+.inr-cv {
+  display: block; width: 148px; aspect-ratio: 2 / 3; margin: 0 auto;
+  border-radius: var(--sn-radius-sm); border: 1px solid var(--sn-border);
+  background: var(--sn-panel-inset); image-rendering: pixelated;
+}
+.inr-pstag {
+  display: inline-block; margin-top: 0.4rem; font-family: var(--sn-mono);
+  font-variant-numeric: tabular-nums; font-size: 0.78rem; color: var(--sn-muted);
+}
+.inr-pstag b { color: var(--sn-accent); font-weight: 700; }
+
+/* demo 1: coordinate → colour pipeline */
+.inr-hov-cv { cursor: crosshair; width: 172px; }
+.inr-pipe { display: flex; gap: 0.55rem; align-items: center; flex-wrap: wrap; justify-content: center; margin-top: 0.6rem; }
+.inr-pipe .box {
+  border: 1px solid var(--sn-border); border-radius: var(--sn-radius-sm);
+  background: var(--sn-panel); padding: 0.5rem 0.75rem; text-align: center;
+  font-family: var(--sn-mono); font-variant-numeric: tabular-nums; font-size: 0.85rem;
+}
+.inr-pipe .box .lab { display: block; font-family: inherit; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--sn-muted); margin-bottom: 0.2rem; }
+.inr-pipe .fn { border-color: var(--sn-accent-line); background: var(--sn-accent-soft); color: var(--sn-accent-strong); font-weight: 700; }
+.inr-pipe .arrow { color: var(--sn-muted); font-size: 1.1rem; }
+.inr-sw { display: inline-block; width: 30px; height: 18px; border-radius: 4px; border: 1px solid var(--sn-border); vertical-align: middle; }
+
+/* legend chips for charts */
+.inr-legend { display: flex; gap: 1rem; flex-wrap: wrap; font-size: 0.78rem; margin: 0.35rem 0 0; justify-content: center; }
+.inr-legend span::before { content: "—"; font-weight: 800; margin-right: 0.3rem; }
+.inr-legend .l-relu::before { color: var(--sn-warn); }
+.inr-legend .l-ff::before { color: var(--sn-accent); }
+.inr-legend .l-siren::before { color: var(--sn-good); }
+.inr-legend .l-tgt::before { color: var(--sn-muted); }
+</style>
+
+<p>
+  An <strong>implicit neural representation</strong> (INR, also called a <em>coordinate
+  network</em>) stores a signal as a function instead of a table of samples: a small network
+  <span class="inr-readout">f<sub>θ</sub>(x, y) → (R, G, B)</span> maps continuous pixel
+  coordinates to colours, so the network's weights <em>are</em> the image. Three questions make
+  the idea interesting, and this note answers each with a network training live in the page: why
+  does the obvious attempt — a plain ReLU MLP on raw coordinates — only ever learn a blurry
+  version of the image (spectral bias); how do random Fourier features and SIREN's sine
+  activations fix it; and what does the functional view buy (a representation that can be
+  rendered at <em>any</em> resolution, integer or not).
+</p>
+
+<div class="se-note">
+  <strong>One-sentence summary.</strong> Fitting an image with a coordinate network is ordinary
+  supervised regression — one (coordinate, colour) pair per pixel — but gradient descent learns
+  low frequencies first and high frequencies almost never (<em>spectral bias</em>), so the input
+  must be lifted to a frequency-rich basis (Fourier features) or the activations made periodic
+  (SIREN); once trained, the network is a continuous function that can be sampled on any grid,
+  which is the mechanism behind arbitrary-scale rendering, NeRF, and friends.
+</div>
+
+<!-- ============================================================ -->
+<!-- 1. THE IMAGE AS A FUNCTION                                    -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🗺️ An image is a dataset of coordinate–colour pairs</h3>
+  <p style="margin-top:0">
+    A stored image defines colour only at integer pixel locations. The implicit view instead
+    treats the picture as an unknown continuous function and fits a network to it. The training
+    set is the image itself — one sample per pixel, with the pixel-centre coordinate (normalized
+    to [−1, 1]²) as input and the RGB value as target:
+  </p>
+
+  <div class="se-equation">
+    𝒟 = { ((x<sub>i</sub>, y<sub>i</sub>), c<sub>i</sub>) }<sub>i=1…H·W</sub>
+    &nbsp;&nbsp;&nbsp;
+    ℒ(θ) = (1 / HW) · Σ<sub>i</sub> ‖ f<sub>θ</sub>(x<sub>i</sub>, y<sub>i</sub>) − c<sub>i</sub> ‖²
+  </div>
+
+  <p>
+    Move the cursor over the image (kodim19, the classic Kodak “lighthouse” test image) to read
+    off training pairs. The picket fence and the railing are dense high-frequency detail — they
+    are exactly what will separate the models below.
+  </p>
+
+  <div class="inr-flexwrap">
+    <div class="inr-panel">
+      <canvas id="inr-hover-cv" class="inr-cv inr-hov-cv" width="96" height="144"></canvas>
+      <div class="inr-pstag">96 × 144 = 13,824 training pairs</div>
+    </div>
+    <div class="inr-pipe">
+      <div class="box"><span class="lab">input coordinate</span><span id="inr-hov-xy">(+0.00, +0.00)</span></div>
+      <div class="arrow">→</div>
+      <div class="box fn">f<sub>θ</sub></div>
+      <div class="arrow">→</div>
+      <div class="box"><span class="lab">target colour</span><span class="inr-sw" id="inr-hov-sw"></span> <span id="inr-hov-rgb">(0.00, 0.00, 0.00)</span></div>
+    </div>
+  </div>
+
+  <p style="font-size:0.9rem; margin-bottom:0">
+    Two conventions matter later. Coordinates use <em>pixel centres</em> (a half-pixel offset),
+    so grids of different resolutions sample the same continuous domain consistently — this
+    detail is what makes “render the same network at a new resolution” geometrically meaningful.
+    And reconstruction quality is measured as PSNR = −10·log₁₀ MSE (in dB, for colours in
+    [0, 1]): 20 dB is visibly blurry, 30 dB is a faithful reconstruction at this size.
+  </p>
+</div>
+
+<!-- ============================================================ -->
+<!-- 2. SPECTRAL BIAS IN 1-D                                       -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🌊 Spectral bias: gradient descent learns low frequencies first</h3>
+  <p style="margin-top:0">
+    Neural networks trained by gradient descent fit the low-frequency content of a target first,
+    and for low-dimensional inputs like a coordinate the high frequencies arrive so slowly that
+    they effectively never come (Rahaman et al., 2019). In neural-tangent-kernel language: the
+    kernel eigenvalues associated with high-frequency components are tiny, so those components
+    converge at a correspondingly tiny rate. The cleanest place to watch it is one dimension.
+    The target below is a sum of three sines — frequencies 0.5, 3 and 8 cycles — and two
+    identical ReLU MLPs fit it, one on the raw coordinate x, one on a Fourier-feature lift of x.
+  </p>
+
+  <div class="inr-controls" style="justify-content:center">
+    <button class="se-btn" id="inr-1d-play">▶ train</button>
+    <button class="se-reset" id="inr-1d-reset">reset</button>
+    <span style="font-size:0.82rem; color:var(--sn-muted)">step <span class="inr-readout" id="inr-1d-step">0</span></span>
+  </div>
+
+  <div class="graph-wrap"><svg id="inr-1d-chart" viewBox="0 0 560 240" width="100%"></svg></div>
+  <div class="inr-legend">
+    <span class="l-tgt">target y(x)</span>
+    <span class="l-relu">ReLU MLP on raw x</span>
+    <span class="l-ff">same MLP on Fourier features of x</span>
+  </div>
+
+  <p style="font-size:0.9rem">
+    The bars track how much of each frequency component is still missing from each fit
+    (amplitude of the residual at that frequency):
+  </p>
+  <div class="graph-wrap"><svg id="inr-1d-bars" viewBox="0 0 560 170" width="100%"></svg></div>
+
+  <p style="font-size:0.9rem; margin-bottom:0">
+    The raw-coordinate MLP kills the 0.5-cycle component almost immediately, grinds down the
+    3-cycle one, and barely touches the 8-cycle one — more steps do not help, because that
+    component converges exponentially slower than the others. The Fourier-feature model treats
+    all three frequencies as equally easy. This is not underfitting in the usual sense: both
+    networks have the same capacity, and only the <em>input parametrization</em> differs.
+  </p>
+</div>
+
+<!-- ============================================================ -->
+<!-- 3. THE RACE ON THE LIGHTHOUSE                                 -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🏁 Three networks, one lighthouse</h3>
+  <p style="margin-top:0">
+    The same failure and the same two classic fixes, now on the actual image. All three models
+    are MLPs of identical size (3 hidden layers, width 36) trained with Adam on minibatches of
+    pixels; the only difference is how the coordinate enters the network.
+  </p>
+  <ul style="font-size:0.92rem">
+    <li>
+      <strong>ReLU MLP</strong> — raw (x, y) in, colours out. The baseline that spectral bias
+      condemns to blur.
+    </li>
+    <li>
+      <strong>Random Fourier features</strong> (Tancik et al., 2020) — lift the coordinate
+      through a fixed random projection before the very same ReLU MLP:
+      <div class="se-equation" style="margin:0.5rem 0">
+        γ(v) = [ sin(2πBv), cos(2πBv) ], &nbsp; B ∈ ℝ<sup>m×2</sup>, &nbsp; B<sub>ij</sub> ∼ 𝒩(0, σ²)
+      </div>
+      In NTK terms the mapping makes the network's kernel stationary with a bandwidth set by σ —
+      the network becomes equally willing to learn every frequency up to that bandwidth. σ is
+      the one knob: too small and the result is still blurry, too large and the network wastes
+      capacity fitting frequencies finer than the pixels, which shows up as slow-to-clear
+      speckle.
+    </li>
+    <li>
+      <strong>SIREN</strong> (Sitzmann et al., 2020) — attack the problem from inside the
+      network instead: replace every ReLU with a sine,
+      <div class="se-equation" style="margin:0.5rem 0">
+        h<sub>l+1</sub> = sin( ω₀ · (W<sub>l</sub> h<sub>l</sub> + b<sub>l</sub>) )
+      </div>
+      with two load-bearing details from the paper: a frequency scale ω₀ = 30, and weights
+      initialized uniformly in ±√(6 / fan_in) / ω₀ so that activations stay well-distributed
+      through depth and deep sine stacks train stably. High frequencies are available from step
+      one.
+    </li>
+  </ul>
+
+  <p style="font-size:0.92rem">
+    Press train. The networks fit a 48 × 72 version of the image, live. Watch the fence: it is
+    the first thing the ReLU model gives up on and the last thing the others perfect.
+  </p>
+
+  <div class="inr-controls" style="justify-content:center">
+    <button class="se-btn" id="inr-race-play">▶ train</button>
+    <button class="se-reset" id="inr-race-reset">reset</button>
+    <span style="font-size:0.82rem; color:var(--sn-muted)">step <span class="inr-readout" id="inr-race-step">0</span> / 1800</span>
+    <label style="font-size:0.82rem">Fourier σ
+      <input type="range" id="inr-race-sigma" min="1" max="12" step="1" value="3" style="width:110px; vertical-align:middle">
+      <span class="inr-readout" id="inr-race-sigma-out">3</span>
+    </label>
+  </div>
+
+  <div class="inr-flexwrap">
+    <div class="inr-panel">
+      <h4>target</h4>
+      <canvas id="inr-race-target" class="inr-cv" width="48" height="72"></canvas>
+      <div class="inr-pstag">48 × 72</div>
+    </div>
+    <div class="inr-panel">
+      <h4 style="color:var(--sn-warn)">ReLU MLP</h4>
+      <canvas id="inr-race-cv-relu" class="inr-cv" width="48" height="72"></canvas>
+      <div class="inr-pstag" id="inr-race-psnr-relu">— dB</div>
+    </div>
+    <div class="inr-panel">
+      <h4 style="color:var(--sn-accent)">Fourier features</h4>
+      <canvas id="inr-race-cv-fourier" class="inr-cv" width="48" height="72"></canvas>
+      <div class="inr-pstag" id="inr-race-psnr-fourier">— dB</div>
+    </div>
+    <div class="inr-panel">
+      <h4 style="color:var(--sn-good)">SIREN</h4>
+      <canvas id="inr-race-cv-siren" class="inr-cv" width="48" height="72"></canvas>
+      <div class="inr-pstag" id="inr-race-psnr-siren">— dB</div>
+    </div>
+  </div>
+
+  <div class="graph-wrap" style="margin-top:0.9rem"><svg id="inr-race-chart" viewBox="0 0 560 280" width="100%"></svg></div>
+  <div class="inr-legend">
+    <span class="l-relu">ReLU MLP</span>
+    <span class="l-ff">Fourier features</span>
+    <span class="l-siren">SIREN</span>
+  </div>
+
+  <p style="font-size:0.9rem; margin-bottom:0">
+    The curves are the quantitative version of the story: the ReLU MLP plateaus almost
+    immediately — its remaining error lives in frequencies it learns exponentially slowly —
+    while SIREN jumps ahead within a couple hundred steps and the Fourier-feature model keeps
+    climbing past both. Try σ = 1 (blurry, the bandwidth is too narrow for the fence) and σ = 12
+    (speckle that takes a long time to clean up). One honesty footnote: each model uses the
+    learning rate it likes best (3·10⁻³ / 5·10⁻³ / 10⁻³ respectively) so all three converge as
+    fast as they can in a browser; the ranking matches the full-batch PyTorch version of this
+    experiment.
+  </p>
+</div>
+
+<!-- ============================================================ -->
+<!-- 4. ARBITRARY-SCALE UPSCALING                                  -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🔍 The payoff: one network, sampled at any resolution</h3>
+  <p style="margin-top:0">
+    Nothing about a trained f<sub>θ</sub> knows or cares about the grid it was trained on — it
+    is a continuous function, and a pixel grid is just one way to sample it. So: train a SIREN
+    on a tiny 24 × 36 version of the lighthouse, then evaluate the <em>same weights</em> on any
+    grid, including non-integer scale factors that a pixel-grid pipeline would need special-case
+    resampling for. This “train once, decode at any resolution” mechanism is exactly what
+    learned super-resolution methods like LIIF build on.
+  </p>
+
+  <div class="inr-controls" style="justify-content:center">
+    <button class="se-btn" id="inr-sr-play">▶ fit the low-res image</button>
+    <button class="se-reset" id="inr-sr-reset">reset</button>
+    <span style="font-size:0.82rem; color:var(--sn-muted)" id="inr-sr-prog">untrained</span>
+  </div>
+  <div class="inr-controls" style="justify-content:center">
+    <label style="font-size:0.82rem">render scale
+      <input type="range" id="inr-sr-scale" min="1" max="4" step="0.1" value="4" style="width:170px; vertical-align:middle">
+      <span class="inr-readout" id="inr-sr-scale-out">×4.0</span>
+    </label>
+  </div>
+
+  <div class="inr-flexwrap">
+    <div class="inr-panel">
+      <h4>input (training data)</h4>
+      <canvas id="inr-sr-low" class="inr-cv" width="24" height="36"></canvas>
+      <div class="inr-pstag">24 × 36</div>
+    </div>
+    <div class="inr-panel">
+      <h4>nearest neighbour</h4>
+      <canvas id="inr-sr-near" class="inr-cv" width="24" height="36"></canvas>
+      <div class="inr-pstag" id="inr-sr-psnr-near">&nbsp;</div>
+    </div>
+    <div class="inr-panel">
+      <h4>bicubic</h4>
+      <canvas id="inr-sr-bic" class="inr-cv" width="24" height="36"></canvas>
+      <div class="inr-pstag" id="inr-sr-psnr-bic">&nbsp;</div>
+    </div>
+    <div class="inr-panel">
+      <h4 style="color:var(--sn-good)">INR (SIREN)</h4>
+      <canvas id="inr-sr-inr" class="inr-cv" width="24" height="36"></canvas>
+      <div class="inr-pstag" id="inr-sr-psnr-inr">&nbsp;</div>
+    </div>
+  </div>
+
+  <p style="font-size:0.82rem; color:var(--sn-muted); text-align:center; margin:0.5rem 0 0.9rem">
+    PSNR against the true high-resolution image appears where a ground truth exists
+    (×2 and ×4); at other scales there is nothing exact to compare against.
+  </p>
+
+  <div class="se-note" style="margin-bottom:0">
+    <strong>An honest caveat.</strong> A network fitted to a <em>single</em> low-resolution image
+    has seen no information beyond those 864 pixels, so it cannot invent the fence slats the
+    downsample destroyed — no single-image method can, and the INR lands within a fraction of a
+    dB of bicubic. The difference is the <em>kind</em> of object doing the interpolating: bicubic
+    is a fixed formula tied to the source grid, while the INR is a resolution-free function of
+    which every grid is just one sampling. What pushes implicit super-resolution past bicubic is
+    a learned prior — LIIF (Chen et al., 2021) conditions a local INR on features from an encoder
+    trained across thousands of images, so plausible detail comes from the corpus, not the input.
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- 5. WHERE THIS GOES                                            -->
+<!-- ============================================================ -->
+<div class="se-section">
+  <h3>🧭 Where this goes</h3>
+  <p style="margin-top:0">
+    Everything above generalizes far beyond one photo of a lighthouse. The recipe — coordinates
+    in, signal out, a spectral-bias fix in between — is the backbone of:
+  </p>
+  <ul style="font-size:0.92rem; margin-bottom:0">
+    <li>
+      <strong>3-D shapes and scenes</strong> — DeepSDF and Occupancy Networks represent geometry
+      as f(x, y, z) → distance/occupancy; NeRF represents a whole scene as
+      f(x, y, z, θ, φ) → (colour, density) and renders it along camera rays. NeRF's positional
+      encoding is the deterministic cousin of the Fourier features above.
+    </li>
+    <li>
+      <strong>Learned super-resolution</strong> — LIIF: the continuous-decoding mechanism from
+      the demo plus a learned prior, which is what finally beats bicubic.
+    </li>
+    <li>
+      <strong>Compression</strong> — the SR network above has ≈3.5k parameters and reproduces the
+      image it was trained on; weights-as-image is an actively studied compression scheme.
+    </li>
+    <li>
+      <strong>Physics</strong> — a SIREN is infinitely differentiable, so it can be supervised
+      through its <em>derivatives</em>: fitted to image gradients, or used as the solution
+      ansatz for PDEs and wave equations.
+    </li>
+  </ul>
+</div>
+
+<div class="se-note">
+  <strong>Takeaway.</strong> An implicit neural representation turns “an image” from a grid of
+  samples into a continuous function with learnable weights. The naive fit fails for a
+  fundamental reason — gradient descent's spectral bias starves high frequencies — and both
+  classic fixes work by making high frequencies cheap: Fourier features change the input basis,
+  SIREN changes the activation. Once the function is learned, resolution stops being a property
+  of the image and becomes a property of how it is <em>queried</em>.
+</div>
+
+<p style="font-size:0.85rem; color:var(--sn-muted)">
+  Companion code (PyTorch, with the full-resolution version of every experiment here):
+  <a href="https://github.com/Alexdruso/data-science-stuff/tree/main/implicit_neural_representations">data-science-stuff/implicit_neural_representations</a>.
+  Sources: Sitzmann et al., <em>Implicit Neural Representations with Periodic Activation
+  Functions</em>, NeurIPS 2020 — <a href="https://arxiv.org/abs/2006.09661">arXiv:2006.09661</a>;
+  Tancik et al., <em>Fourier Features Let Networks Learn High Frequency Functions in Low
+  Dimensional Domains</em>, NeurIPS 2020 — <a href="https://arxiv.org/abs/2006.10739">arXiv:2006.10739</a>;
+  Rahaman et al., <em>On the Spectral Bias of Neural Networks</em>, ICML 2019 —
+  <a href="https://arxiv.org/abs/1806.08734">arXiv:1806.08734</a>;
+  Mildenhall et al., <em>NeRF</em>, ECCV 2020 — <a href="https://arxiv.org/abs/2003.08934">arXiv:2003.08934</a>;
+  Chen et al., <em>Learning Continuous Image Representation with Local Implicit Image
+  Function</em> (LIIF), CVPR 2021 — <a href="https://arxiv.org/abs/2012.09161">arXiv:2012.09161</a>.
+  Image: kodim19, <a href="https://r0k.us/graphics/kodak/">Kodak Lossless True Color Image Suite</a>.
+</p>
+
+<script>
+(function () {
+  "use strict";
+
+  /* ---------- shared: theme-adaptive colors ---------- */
+  var SN = document.querySelector(".study-note");
+  function readCols() {
+    var cs = getComputedStyle(SN);
+    function c(n) { return cs.getPropertyValue(n).trim(); }
+    return { accent: c("--sn-accent"), strong: c("--sn-accent-strong"), good: c("--sn-good"),
+             bad: c("--sn-bad"), warn: c("--sn-warn"), muted: c("--sn-muted"),
+             grid: c("--sn-grid"), text: c("--sn-text") };
+  }
+  var COL = readCols();
+  var redrawFns = [];
+  new MutationObserver(function () { COL = readCols(); redrawFns.forEach(function (f) { f(); }); })
+    .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+
+  /* ================================================================
+     Tiny INR engine: Float32Array MLP + Adam, minibatch SGD.
+     Models map 2-D coords in [-1,1]^2 (optionally lifted by fixed
+     random Fourier features) to `out` channels. Mirrors the PyTorch
+     reference implementation in the companion repo.
+     ================================================================ */
+  function makeRng(seed) {
+    var s = seed >>> 0;
+    return function () { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+  }
+
+  function makeLayer(inDim, outDim, act, rng, wBound, omega) {
+    var W = new Float32Array(outDim * inDim), b = new Float32Array(outDim);
+    var bBound = 1 / Math.sqrt(inDim);            // PyTorch default bias init
+    for (var i = 0; i < W.length; i++) W[i] = (rng() * 2 - 1) * wBound;
+    for (var j = 0; j < b.length; j++) b[j] = (rng() * 2 - 1) * bBound;
+    return { inDim: inDim, outDim: outDim, act: act, omega: omega || 0, W: W, b: b,
+             gW: new Float32Array(W.length), gb: new Float32Array(b.length),
+             mW: new Float32Array(W.length), vW: new Float32Array(W.length),
+             mb: new Float32Array(b.length), vb: new Float32Array(b.length),
+             z: null, a: null, d: null };
+  }
+
+  /* kind: "relu" (raw coords) | "fourier" (random-feature lift) | "siren" */
+  function makeModel(kind, opts) {
+    var o = { width: 40, depth: 3, omega: 30, mapping: 32, sigma: 4, seed: 1, out: 3 };
+    for (var k in opts) o[k] = opts[k];
+    var rng = makeRng(o.seed);
+    var m = { kind: kind, layers: [], t: 0, mapB: null, inDim: 2 };
+    if (kind === "fourier") {
+      m.mapB = new Float32Array(o.mapping * 2);   // B ~ N(0, sigma^2), fixed
+      for (var i = 0; i < m.mapB.length; i += 2) {
+        var u1 = Math.max(rng(), 1e-9), u2 = rng(), r = Math.sqrt(-2 * Math.log(u1));
+        m.mapB[i] = o.sigma * r * Math.cos(2 * Math.PI * u2);
+        m.mapB[i + 1] = o.sigma * r * Math.sin(2 * Math.PI * u2);
+      }
+      m.inDim = 2 * o.mapping;
+    }
+    var sine = kind === "siren", din = m.inDim;
+    for (var l = 0; l < o.depth; l++) {
+      var wB = sine ? (l === 0 ? 1 / din : Math.sqrt(6 / din) / o.omega) : Math.sqrt(6 / din);
+      m.layers.push(makeLayer(din, o.width, sine ? "sine" : "relu", rng, wB, o.omega));
+      din = o.width;
+    }
+    var headB = sine ? Math.sqrt(6 / din) / o.omega : 1 / Math.sqrt(din);
+    m.layers.push(makeLayer(din, o.out, "none", rng, headB, 0));
+    return m;
+  }
+
+  /* map raw coords (N x 2) to the model's input features (N x inDim) */
+  function mapInput(model, coords, N, out) {
+    if (model.kind !== "fourier") {
+      if (out !== coords) out.set(coords.subarray(0, N * 2));
+      return out === coords ? coords : out;
+    }
+    var B = model.mapB, m = B.length / 2;
+    for (var n = 0; n < N; n++) {
+      var y = coords[n * 2], x = coords[n * 2 + 1], o = n * 2 * m;
+      for (var j = 0; j < m; j++) {
+        var p = 2 * Math.PI * (B[j * 2] * y + B[j * 2 + 1] * x);
+        out[o + j] = Math.sin(p); out[o + m + j] = Math.cos(p);
+      }
+    }
+    return out;
+  }
+
+  function ensureBufs(model, N) {
+    model.layers.forEach(function (L) {
+      if (!L.z || L.z.length < N * L.outDim) {
+        L.z = new Float32Array(N * L.outDim);
+        L.a = new Float32Array(N * L.outDim);
+        L.d = new Float32Array(N * L.outDim);
+      }
+    });
+  }
+
+  function forward(model, X, N) {
+    ensureBufs(model, N);
+    var cur = X;
+    for (var l = 0; l < model.layers.length; l++) {
+      var L = model.layers[l], inD = L.inDim, outD = L.outDim, W = L.W, b = L.b, z = L.z, a = L.a;
+      for (var n = 0; n < N; n++) {
+        var xo = n * inD, zo = n * outD;
+        for (var o = 0; o < outD; o++) {
+          var s = b[o], wo = o * inD;
+          for (var i = 0; i < inD; i++) s += cur[xo + i] * W[wo + i];
+          z[zo + o] = s;
+        }
+      }
+      var M = N * outD, m;
+      if (L.act === "relu") for (m = 0; m < M; m++) a[m] = z[m] > 0 ? z[m] : 0;
+      else if (L.act === "sine") for (m = 0; m < M; m++) a[m] = Math.sin(L.omega * z[m]);
+      else a.set(z.subarray(0, M));
+      cur = a;
+    }
+    return model.layers[model.layers.length - 1].a;
+  }
+
+  /* one minibatch step: forward, MSE backward, Adam; returns batch MSE */
+  function trainStep(model, X, Y, N, lr) {
+    var pred = forward(model, X, N);
+    var nl = model.layers.length, out = model.layers[nl - 1];
+    var M0 = N * out.outDim, mse = 0, scale = 2 / M0;
+    for (var i = 0; i < M0; i++) {
+      var e = pred[i] - Y[i];
+      mse += e * e;
+      out.d[i] = e * scale;
+    }
+    mse /= M0;
+    for (var l = nl - 1; l >= 0; l--) {
+      var L = model.layers[l], below = l > 0 ? model.layers[l - 1] : null;
+      var inp = below ? below.a : X;
+      var inD = L.inDim, outD = L.outDim, W = L.W, gW = L.gW, gb = L.gb, d = L.d;
+      gW.fill(0); gb.fill(0);
+      for (var n = 0; n < N; n++) {
+        var xo = n * inD, zo = n * outD;
+        for (var o = 0; o < outD; o++) {
+          var g = d[zo + o];
+          if (g === 0) continue;
+          gb[o] += g;
+          var wo = o * inD;
+          for (var k = 0; k < inD; k++) gW[wo + k] += g * inp[xo + k];
+        }
+      }
+      if (below) {
+        var bd = below.d, bz = below.z;
+        for (var n2 = 0; n2 < N; n2++) {
+          var xo2 = n2 * inD, zo2 = n2 * outD;
+          for (var i2 = 0; i2 < inD; i2++) {
+            var s2 = 0;
+            for (var o2 = 0; o2 < outD; o2++) s2 += d[zo2 + o2] * W[o2 * inD + i2];
+            bd[xo2 + i2] = s2;
+          }
+        }
+        var M = N * inD, m2;
+        if (below.act === "relu") { for (m2 = 0; m2 < M; m2++) if (bz[m2] <= 0) bd[m2] = 0; }
+        else if (below.act === "sine") { for (m2 = 0; m2 < M; m2++) bd[m2] *= below.omega * Math.cos(below.omega * bz[m2]); }
+      }
+    }
+    model.t++;
+    var b1 = 0.9, b2 = 0.999, eps = 1e-8;
+    var c1 = 1 - Math.pow(b1, model.t), c2 = 1 - Math.pow(b2, model.t);
+    model.layers.forEach(function (L2) {
+      var W = L2.W, gW = L2.gW, mW = L2.mW, vW = L2.vW;
+      for (var i = 0; i < W.length; i++) {
+        var g = gW[i];
+        mW[i] = b1 * mW[i] + (1 - b1) * g;
+        vW[i] = b2 * vW[i] + (1 - b2) * g * g;
+        W[i] -= lr * (mW[i] / c1) / (Math.sqrt(vW[i] / c2) + eps);
+      }
+      var b = L2.b, gb = L2.gb, mb = L2.mb, vb = L2.vb;
+      for (var j = 0; j < b.length; j++) {
+        var g2 = gb[j];
+        mb[j] = b1 * mb[j] + (1 - b1) * g2;
+        vb[j] = b2 * vb[j] + (1 - b2) * g2 * g2;
+        b[j] -= lr * (mb[j] / c1) / (Math.sqrt(vb[j] / c2) + eps);
+      }
+    });
+    return mse;
+  }
+
+  /* pixel-centre coordinate grid on [-1,1]^2, row-major (y, x) */
+  function makeGrid(h, w) {
+    var g = new Float32Array(h * w * 2);
+    for (var r = 0; r < h; r++) {
+      var y = (r + 0.5) / h * 2 - 1;
+      for (var c = 0; c < w; c++) {
+        g[(r * w + c) * 2] = y;
+        g[(r * w + c) * 2 + 1] = (c + 0.5) / w * 2 - 1;
+      }
+    }
+    return g;
+  }
+
+  function psnrOf(mse) { return -10 * Math.log10(Math.max(mse, 1e-12)); }
+
+  /* ---------- image helpers ---------- */
+  function drawPixels(canvas, px, w, h) {   /* px: Float32Array [0,1], w*h*3 */
+    canvas.width = w; canvas.height = h;
+    var ctx = canvas.getContext("2d"), im = ctx.createImageData(w, h), d = im.data;
+    for (var i = 0, j = 0; i < w * h * 3; i += 3, j += 4) {
+      d[j]     = Math.max(0, Math.min(255, Math.round(px[i] * 255)));
+      d[j + 1] = Math.max(0, Math.min(255, Math.round(px[i + 1] * 255)));
+      d[j + 2] = Math.max(0, Math.min(255, Math.round(px[i + 2] * 255)));
+      d[j + 3] = 255;
+    }
+    ctx.putImageData(im, 0, 0);
+  }
+
+  function areaDownsample(src, sw, sh, f) {  /* integer-factor area average */
+    var w = Math.floor(sw / f), h = Math.floor(sh / f), out = new Float32Array(w * h * 3);
+    for (var r = 0; r < h; r++) for (var c = 0; c < w; c++) {
+      var s0 = 0, s1 = 0, s2 = 0;
+      for (var dr = 0; dr < f; dr++) for (var dc = 0; dc < f; dc++) {
+        var i = ((r * f + dr) * sw + (c * f + dc)) * 3;
+        s0 += src[i]; s1 += src[i + 1]; s2 += src[i + 2];
+      }
+      var o = (r * w + c) * 3, n = f * f;
+      out[o] = s0 / n; out[o + 1] = s1 / n; out[o + 2] = s2 / n;
+    }
+    return out;
+  }
+
+  function imagePsnr(a, b, len) {
+    var mse = 0;
+    for (var i = 0; i < len; i++) { var e = a[i] - b[i]; mse += e * e; }
+    return psnrOf(mse / len);
+  }
+
+  /* the target image: kodim19 "lighthouse" (Kodak suite), 96x144, embedded */
+  var LIGHTHOUSE = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACQAGADASIAAhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAABAUGBwIDCAEA/8QAOhAAAgECBAQEBAUDAwQDAAAAAQIDBBEABRIhBhMxQQdRYXEiMoGRFCNCobEVUsFygtEkJ2JjouHw/8QAGgEAAwEBAQEAAAAAAAAAAAAAAgMEAQUABv/EACgRAAIBAwMEAQQDAAAAAAAAAAECAAMRIQQSMRMiQVFhBTJxgbHB0f/aAAwDAQACEQMRAD8AglVl09NOCB8PceWAqyq/DAOFLDtfE5kQSyDmr7HGmbK4pY2AQbja4xUK1uZN078SCQ5g8znloUJ2G+GCQySRltZEo6j+72xorMtnpswdeTJF3uBtjWslQlniJfTtc98ONjkQRccw+FtB08wKx6kjfG+TXGiukrfW2B6KGqrJTZAPV8G1OV1gh0rIH8h2H1wokA2vGAG0YZXmgSRI2YBj3vhtU5u0CcyM6mPYnEDnhlgUI8IV73B3/nBlLFJGyTVcczi29zcD12wLUgczwc8R7NxQ6KwdgWtYWN7HCefiXMHXk8zSAO4uTg2eakdU5VNpH92i+NQyRap1KykE9CRvbGrsUZExtx4MGgSR0Z3kkDHdn02vh3TS1hliSKqkEQtqJ8vTGcOQVEMSlZlcAd13GDKFFEpCyjY2NxYn0wJqA8TwQjmJlzB3S6NuBcg4xGetG68/cX2A3xHebUgflz9exAwRS1Zhu1QxkYG+2HGkIAcx89fT10qsQdNvjHc/fGqTh+lqiXpqrl2NyvXAUNdTVLqXQIei3OGiGzBzqVx+pd9sIYFOMRykNzBlpXyxSCWk23J7euCI2rZ/kUMhXfSd/scGaqeVAZl+K25tsRguOMIoNOiOp3sO2Fl/fMMLAFlSVGgqMukNtt0JwpyavizmStFJT1MaUtZJSyLMALshsSpB6YQeKVdmCVlPTRZxNQ0C0+uYU8hjZnLWs7jothsLi9zfEQyNcrjzIf0SvqaSqZbq0FSSzPt2ub99rb4A1beJuy8vKCigVToj0lu5O+DaSnWCS7RM972072wzySmaq4Yo2reRJU8hOc0a2GvSCdu256YM/ASRKpp2j9VYdcINa8aKcGo6WA/GHdbm9nGDDk+XyOX5Caib3AtfH0byBgskQuO43wwhkZSp5Kkd7bYUXN8Q9olGvkzayVkkBHmOmMXopo10M2x7lcTbntJVE6Izt0Yb3wPNVIoIqKQoB0ZBcY63Xb1IOksg01I8YDjSw8xhhSZhUxoAQzD3Bw7qI6SeNjBUKXt8nQ4ApqIByJqZSO1sF1Aw7hM2EHEZ0lfrtdCdvK9sMJpSuXyzwTchlQsWtsLDrbC+KlhRNQsnfbBFhLE1O6B4pFKOvmCNx9sTOAeI9SRzKR4y/qfidnlLJkNJOMvpYuSsso0LIQzEuo66d+p3/jG+j8I+Mo4efDSpUXHyo2/8YuLgzJKKJ4KOGEilhARVAvsBYXP0x0Tw1FRxZdDGXgiQ25eplX6DHL1OrNLAEto0Q/MoDgbidq6umyWupZ8vzOgp4xPBP1cWC6ge63Bt3FziexOsl11KT2OHviVwtlNNxlScVR0qrX1dF+DlnT9SI+obdL/HufQeWIys1NDGCYC1hsb2/bAU6gqoHHmE67G2mM6eBWf4RZu488b2pnQLoX6YUDMEJDKCh98ETZqEgDySM1v7TgwjEwCyyASUiU1QW/NN/wDcMZR18CflyW9A1xhRC3EyoWoWgzeJd/8AopEqWt5lFOtR/qAxpGf08s5irqXkyDZuux9fLFq6im+CZKaTrkR3JJlUsl2p1Vv7lxsCRHaDofXCtDStaWJ9u19749OYinvK1lXp54cU9QA/uOVodSbgH9zgyKlkp6eWV4xpRSwFtthfEbpuL446grJTMEBsHvf7+X0v9MNKniZKjKJ44rfEhTY9Li2JyxbAjhYZMI4PWMVMcbFAT8uo6dXp1AxJfETPs4yag4cXJ81q6IzTypKYZbawNFr29za3mcJuFUBggLLpButzYC59bf574uvhpFYKZoHDH4b/ADAfvvjkap9rbrS6gt1tAePVNT4eZHmUxkMilQ9zvd47k/dcVfUNE6m0jKfM9MXZ4h0nO8Nqk6X/ACnie/X9QX/OKYjijC20/c4PQNen+5mqXviuOJ2uVZpiP02NsGUkFQqhY8vU2NwWwxi0p8oUfTBCzPsA9vfHR6hkewTZnPghlFUBy5otR3Alitf2YH+QMVZlGScVZjnhySkrpq1YInlENYBUoiqQPhSXUF6j5bY6znjZKSWdVbSELExnUOnl298c5eAsvEUnH+ZR59BnIaOhYh8ypSjm8ibByNTbXxyaVdjTYtm0sakA4C4iLMOGs5yzVLWcNNELatVE7w6vUq+tT7LYe2IxFT1VdnLR1EVVCqrqEc8XLNr9tyCPUde+OxJgjNoYAo9z1B+//wBj64qjxDo6dM7peWmlEpigFuwOCo6xj2eJ6ppwO6VVLl8ZhCBQLCwsMK1o6n8clLBDJLI5IRIwWbz2tucSmdVBNu2JF4dcPZZxFxwtBmkHNp2hkJUeYHXFDuAhY+IpVJawke4V4gjynMRQZzCViY6eZICGjN/1DuLj3G/06F4Xbmwo0Y1RkBhZb7W67rY/Q4VZh4Oxu4GX5s5htYQVqCZRt2DAgfQDDng/hN+FqaShqnpQxfXGKctpQWG41XIJ72Fum18cuvXVxgy2lTZTkSScTwfi/DvOY1ViRSSSAFSCSq6gPXdccxLndukTH646yjhSqoZqaSUNzEaPf5dJFjbYY4ihzuiSBYqyrp461YwZYWcKQ1jcb/6W+2Lvo+1g6t8ST6iWBUrJd/W5bfCgGPlzia92Fz2xWmUcWZnNnUKVAjmp6pwiQooVk1EEG99wFvfzxOe+O6q0yMCct2dTkzqeeRpACsMkQA6R9DgOVIvnkkUH/wBsRX/5DfFMwZv4kryud4k5q+r+jHQKKiUE1bWlTaDsB8J+98EZTx7nseUZjUZ/xnmgp4aqSkiqlhpza07aHYCIfpTQbdmJtqAOPkGSwJvxPpkoszimuSeJa0silD+Yjdekms9PXfFVeI0zLm1Jq1MDE24Fu/fEBy/xZ4vovE2/EGZ8rL9chZJX5scoUGyovX4jYAiw3v0GLYmmpc34dhzOozukji5Et5mUXcaSwYKOwTfz+F7i+FU9StOoqPgnge4/WaE01urBl9ji/qVW1JX1FzBQVTje5ETG1uvbE78KaKuoPEGKoqKOWnjSnku8ilRuPXD6oq8igkqUeoqpncVN+VGF3V9bDfuLix7nGuDiDLKaJa+loqg82LQpkcegsbYtfUllK2nPWiFYG8eUef8AFVTQtLV1ccTGW9mN2UE7CwPTcDHr5jnctW7vmyXOkoQjXt07NhQufvpIjoYEUMVtu24KC/749/q1VJCJQ+gJFG1kUDqv/OJfwI/9x/R8RZ1S0oE9bLMeaxDWNtOo2G5HYjFQVHhBwHXZxNXVtJLPJPKZJFSQgsTe/wAva5J2xMY55qyKOxkcj5i3ba+/2wBmfE/D/DFMtdmmZRRAHSEO5dhsdIG56joMNTcp7TaLbafulOcF5HwxWeO3FOW0UFZFl2ToFp0mLAxsxIfSCb26gMTuNwNzixc6yTLMvywvTNOZY9K3Y3Db2ufXFZUXiPlr+NvEGcU2U188VXQQQrGCisNDMLm57rbBXGPiPSZxkrZT+CzPLWm03qlIYrYg22O4PTHTSuyuuTbEhdFYHE6GbiXLKbOFy6j4apEZavKqB5n06n1xGRW6XvGuwuftiuaDMs04qy+uqxwdS8SvU1utsvWpamWMam0yXFyVHQgm12GH0p/7iODsDxZRxW9IcqLfyMVflWZ8KScILk3FBzpTKkEgGVFUkcsmrQWb4dJvc9/hGOelIMrD2JVT1JpVVf0fx/FpY+bmeLNooajM+AOFqmOnJCLTx19astzdbHUQukX1W+nkvR56zKqyQ5xLnCShwtY8Bp1mJpau7LHYaRcAdP04gdPxjw7lEF+DOAMqpAImZKrNGatlP5PMDANZVNiNgD1xYWYcX5Tl2QT13F1ZI9QjSokEahHfS9bGgCC1hoK9LdQe+FVaBJVnGQf6P+x76imRspHHyLRxmifn5dWBYwlVVTLpjv8ABrjXY389JPfrha7in4ey6nk2mE2kodmtq628sVRSeN2dPnucR0tCKalnuaNmUsISi2S/0BBtvZ272tCMx4r4nzrM5cwrq2cSyrokVAUXTe/QYPpESNtQBkTqET0sFPrr8wpqXVLIVR21SOA6E6UFyTYHtiNZxxvLRCnGUZDUVEahVnlrZo4EZRGy2C6r3uwP+3HPhqXSU1ccssUy7mUSkMD73vgaurK7M1iSozGrqBGdQWV9Y/fGrTzmYdSCLEWlzZrxhxxm0bGjny7LIiLLFEOaV2I67Dv5H3xX2dZNnr5dPNW1tZXO516YVeWQt0uNtiAT3HTEby6SNCUrMrpHS+0muVD9dLAYKrMwpaOFqiny2WVEvdaWolZ7WvcK0lyOvTFCoAbAz25WGTItRQcRUmazVE+QZrHJKwjDGkmsieYtbfv9Tix5sszStoYqt8vsCA4IJSQd/lbcHCHK86hzOBZYq3MaHUbaJpnQj3+IgfXE2o6/KqfLqenzPM5jOQRraR2UnqCSNvvhtdt1scTUUcAy5VhzDMuL6iahpJJAnFWYl5rHRGY6HlJqboLtsPrirc5y/hvhielbifPkE8UFE/4KiHMkJWnZGUnou7XB77YH498fc+z6R6LhuRaKMVdQryIA3NiIEcZudw2m5NrWJHlipDR5nWVklRX1ZZ33DNcliB3JwlAV+Ihju+0XkrzXjmg/o8dBwvlJyxUgSB6qW800n5QiJv8AouFHTEbRK2ul52YVEtQ77huYSx3uSe/Un74MyujmQaHW6Na4QdfbEgnjhWIMYGiA36b/AFPXAs8dTobxdoiakgPLfVZraXOm338jjcsUKwGQTvYKSxUnb3++GTlRC2hI49YvubE+eFslIsgDCW1iA12Fz5i9v84Xe8NkC8Ty+kBVuy37pYk/xgapidpSSAE7X3ODUjli0hZWDdbA3A89x1xtdIHJUMSRuAV39d8bxFshIicRoGIu179xsMeuQyIqTRud7kNYG3pt/GGbUkkqnQgUnq3l72wI+XpGWEhOoi4B2/fv74IGLNIgYE0rKxVw0aC21m2+mPXfmALFDYWsBfUP2xnHl8jaiTYAAqCCdXtjxkeJtTBNI323IwYzCRD5gi5TyalYYahChGouT++42GHIMBoo4nAl0GyED5jhHPNlyUwFFHKsh2IYnp6Y9jrGhpommZAoBDQ6blj2ufIY0gmDTdFNo/FcyxskBkhbTZGIuBb/AMR6nGx6+xRZmWZj8XLjFyfe/QdMKI6tZqTTBo8yWNr7dQvljdQRrFUA84P11WX/APeZwBUS1H3CMahRUU/NnBjLC9y3b98YoKNKcOoDCwUgkXA8wb9caZKingcA7bW1l7X9h/jAq1ShnKaNNyFuAwFh1PmcYFmMVvGCfhRUWMpC9Re4v33t5+2MpOXIW5NgpsCQb2337YXQ5mi0jFkhMnRW0gbX7YzarKzXp5SiRk6QTbUvb4ext2x7aYO8GMJ1daRXusZXqLfEP+MaDWU7gapBIegJNwT/AIOFxzaoNY0czrFEQANFzc+wAxhO1EYuStUdaMH26W6np/OCCW5niw8Rm0r8gkHQw6iI3Fz98L5qidpGiahUAqCGViL29u+MopzHESrRhCbg6dredsa0kNSzMrsTfSFAB29cGotC3eJ//9k=";
+
+  var IMG = { w: 96, h: 144, px: null };
+  var img = new Image();
+  img.onload = function () {
+    var cv = document.createElement("canvas");
+    cv.width = IMG.w; cv.height = IMG.h;
+    var ctx = cv.getContext("2d");
+    ctx.drawImage(img, 0, 0, IMG.w, IMG.h);
+    var d = ctx.getImageData(0, 0, IMG.w, IMG.h).data;
+    IMG.px = new Float32Array(IMG.w * IMG.h * 3);
+    for (var i = 0, j = 0; j < d.length; i += 3, j += 4) {
+      IMG.px[i] = d[j] / 255; IMG.px[i + 1] = d[j + 1] / 255; IMG.px[i + 2] = d[j + 2] / 255;
+    }
+    initHoverDemo();
+    initRaceDemo();
+    initSrDemo();
+  };
+  img.src = LIGHTHOUSE;
+
+  /* ================================================================
+     Demo 1: hover — the image as (coordinate, colour) pairs
+     ================================================================ */
+  function initHoverDemo() {
+    var cv = document.getElementById("inr-hover-cv");
+    drawPixels(cv, IMG.px, IMG.w, IMG.h);
+    var xyOut = document.getElementById("inr-hov-xy");
+    var swOut = document.getElementById("inr-hov-sw");
+    var rgbOut = document.getElementById("inr-hov-rgb");
+    function fmt(v) { return (v >= 0 ? "+" : "") + v.toFixed(2); }
+    function show(col, row) {
+      col = Math.max(0, Math.min(IMG.w - 1, col));
+      row = Math.max(0, Math.min(IMG.h - 1, row));
+      var x = (col + 0.5) / IMG.w * 2 - 1, y = (row + 0.5) / IMG.h * 2 - 1;
+      var i = (row * IMG.w + col) * 3;
+      var r = IMG.px[i], g = IMG.px[i + 1], b = IMG.px[i + 2];
+      xyOut.textContent = "(" + fmt(x) + ", " + fmt(y) + ")";
+      rgbOut.textContent = "(" + r.toFixed(2) + ", " + g.toFixed(2) + ", " + b.toFixed(2) + ")";
+      swOut.style.background = "rgb(" + Math.round(r * 255) + "," + Math.round(g * 255) + "," + Math.round(b * 255) + ")";
+    }
+    cv.addEventListener("mousemove", function (e) {
+      var rect = cv.getBoundingClientRect();
+      show(Math.floor((e.clientX - rect.left) / rect.width * IMG.w),
+           Math.floor((e.clientY - rect.top) / rect.height * IMG.h));
+    });
+    show(Math.floor(IMG.w * 0.42), Math.floor(IMG.h * 0.25));  /* start on the lighthouse */
+  }
+
+  /* ================================================================
+     Demo 2: spectral bias in 1-D
+     ================================================================ */
+  (function () {
+    var FREQS = [0.5, 3, 8], AMPS = [0.5, 0.3, 0.2], N = 192, MAX = 1600, LR = 2e-3;
+    var X = new Float32Array(N * 2), Y = new Float32Array(N);
+    for (var i = 0; i < N; i++) {
+      var x = (i + 0.5) / N * 2 - 1;
+      X[i * 2] = x; X[i * 2 + 1] = 0;
+      var y = 0;
+      for (var k = 0; k < 3; k++) y += AMPS[k] * Math.sin(2 * Math.PI * FREQS[k] * x);
+      Y[i] = y;
+    }
+    var models, feats, step, running = false;
+    function init() {
+      step = 0;
+      models = {
+        relu: makeModel("relu", { width: 48, depth: 2, out: 1, seed: 2 }),
+        ff:   makeModel("fourier", { width: 48, depth: 2, out: 1, mapping: 16, sigma: 3, seed: 2 })
+      };
+      feats = {};
+      ["relu", "ff"].forEach(function (key) {
+        feats[key] = new Float32Array(N * models[key].inDim);
+        mapInput(models[key], X, N, feats[key]);
+        forward(models[key], feats[key], N);   /* populate prediction buffers */
+      });
+    }
+    function predOf(key) { return models[key].layers[models[key].layers.length - 1].a; }
+    function residAmps(key) {
+      var pred = predOf(key), amps = [];
+      for (var k = 0; k < 3; k++) {
+        var s = 0, c = 0;
+        for (var i = 0; i < N; i++) {
+          var r = Y[i] - pred[i], ph = 2 * Math.PI * FREQS[k] * X[i * 2];
+          s += r * Math.sin(ph); c += r * Math.cos(ph);
+        }
+        amps.push(2 * Math.sqrt(s * s + c * c) / N);
+      }
+      return amps;
+    }
+
+    var chart = document.getElementById("inr-1d-chart");
+    var bars = document.getElementById("inr-1d-bars");
+    var stepOut = document.getElementById("inr-1d-step");
+    var W = 560, H = 240, L = 34, R = 12, T = 10, B = 22;
+    function px(x) { return L + (x + 1) / 2 * (W - L - R); }
+    function py(y) { return T + (1.15 - y) / 2.3 * (H - T - B); }
+    function poly(vals) {
+      var s = "";
+      for (var i = 0; i < N; i++) s += px(X[i * 2]).toFixed(1) + "," + py(vals[i]).toFixed(1) + " ";
+      return s;
+    }
+    function draw() {
+      stepOut.textContent = step;
+      var s = "";
+      [-1, 0, 1].forEach(function (g) {
+        s += '<line x1="' + L + '" y1="' + py(g) + '" x2="' + (W - R) + '" y2="' + py(g) + '" stroke="' + COL.grid + '" stroke-width="1"/>' +
+             '<text x="' + (L - 6) + '" y="' + (py(g) + 4) + '" font-size="10" text-anchor="end" fill="' + COL.muted + '">' + g + '</text>';
+      });
+      s += '<text x="' + (W - R) + '" y="' + (H - 6) + '" font-size="10" text-anchor="end" fill="' + COL.muted + '">x</text>';
+      s += '<polyline points="' + poly(Y) + '" fill="none" stroke="' + COL.muted + '" stroke-width="1.6" stroke-dasharray="5 4" opacity="0.8"/>';
+      s += '<polyline points="' + poly(predOf("relu")) + '" fill="none" stroke="' + COL.warn + '" stroke-width="2"/>';
+      s += '<polyline points="' + poly(predOf("ff")) + '" fill="none" stroke="' + COL.accent + '" stroke-width="2"/>';
+      chart.innerHTML = s;
+
+      var ampsR = residAmps("relu"), ampsF = residAmps("ff");
+      var bw = 46, gap = 118, x0 = 120, base = 130, hmax = 100, bs = "";
+      bs += '<text x="12" y="18" font-size="11" fill="' + COL.text + '">missing amplitude per frequency component</text>';
+      for (var k = 0; k < 3; k++) {
+        var gx = x0 + k * gap;
+        var hR = Math.min(1, ampsR[k] / 0.6) * hmax, hF = Math.min(1, ampsF[k] / 0.6) * hmax;
+        bs += '<rect x="' + gx + '" y="' + (base - hR) + '" width="' + bw + '" height="' + Math.max(1.5, hR) + '" rx="3" fill="' + COL.warn + '" opacity="0.85"/>' +
+              '<rect x="' + (gx + bw + 6) + '" y="' + (base - hF) + '" width="' + bw + '" height="' + Math.max(1.5, hF) + '" rx="3" fill="' + COL.accent + '" opacity="0.85"/>' +
+              '<line x1="' + (gx - 14) + '" y1="' + base + '" x2="' + (gx + 2 * bw + 20) + '" y2="' + base + '" stroke="' + COL.grid + '"/>' +
+              '<text x="' + (gx + bw + 3) + '" y="' + (base + 18) + '" font-size="11" text-anchor="middle" fill="' + COL.muted + '">' + FREQS[k] + ' cycles</text>' +
+              '<text x="' + gx + '" y="' + (base - hR - 5) + '" font-size="9" fill="' + COL.warn + '">' + ampsR[k].toFixed(2) + '</text>' +
+              '<text x="' + (gx + bw + 6) + '" y="' + (base - hF - 5) + '" font-size="9" fill="' + COL.accent + '">' + ampsF[k].toFixed(2) + '</text>';
+      }
+      bars.innerHTML = bs;
+    }
+
+    var playBtn = document.getElementById("inr-1d-play");
+    function frame() {
+      if (!running) return;
+      var t0 = performance.now();
+      while (performance.now() - t0 < 8 && step < MAX) {
+        trainStep(models.relu, feats.relu, Y, N, LR);
+        trainStep(models.ff, feats.ff, Y, N, LR);
+        step++;
+      }
+      draw();
+      if (step >= MAX) { running = false; playBtn.textContent = "▶ train"; return; }
+      requestAnimationFrame(frame);
+    }
+    playBtn.addEventListener("click", function () {
+      if (running) { running = false; playBtn.textContent = "▶ train"; return; }
+      if (step >= MAX) { init(); }
+      running = true; playBtn.textContent = "❚❚ pause";
+      requestAnimationFrame(frame);
+    });
+    document.getElementById("inr-1d-reset").addEventListener("click", function () {
+      running = false; playBtn.textContent = "▶ train"; init(); draw();
+    });
+    redrawFns.push(draw);
+    init(); draw();
+  })();
+
+  /* ================================================================
+     Demo 3: the race — ReLU vs Fourier features vs SIREN
+     ================================================================ */
+  var initRaceDemo = function () {};   /* replaced below once defined */
+  initRaceDemo = function () {
+    var TW = 48, TH = 72, P = TW * TH, MAX = 1800, BATCH = 224, EVAL = 60;
+    var target = areaDownsample(IMG.px, IMG.w, IMG.h, 2);
+    drawPixels(document.getElementById("inr-race-target"), target, TW, TH);
+    var grid = makeGrid(TH, TW);
+
+    var KINDS = ["relu", "fourier", "siren"];
+    var LRS = { relu: 3e-3, fourier: 5e-3, siren: 1e-3 };
+    var sigma = 3;
+    var models, feats, curves, lastEval, step, running = false, rot = 0;
+    var batchRng = makeRng(42);
+    var cvs = {}, tags = {};
+    KINDS.forEach(function (kk) {
+      cvs[kk] = document.getElementById("inr-race-cv-" + kk);
+      tags[kk] = document.getElementById("inr-race-psnr-" + kk);
+    });
+
+    function buildModel(kind) {
+      var opts = { width: 36, depth: 3, seed: 1 };
+      if (kind === "fourier") { opts.mapping = 32; opts.sigma = sigma; }
+      if (kind === "siren") opts.omega = 30;
+      models[kind] = makeModel(kind, opts);
+      feats[kind] = new Float32Array(P * models[kind].inDim);
+      mapInput(models[kind], grid, P, feats[kind]);
+      curves[kind] = [];
+      lastEval[kind] = -1;
+    }
+    function init() {
+      step = 0; rot = 0;
+      models = {}; feats = {}; curves = {}; lastEval = {};
+      KINDS.forEach(buildModel);
+      KINDS.forEach(function (kk) { evalModel(kk); });
+    }
+    function evalModel(kind) {
+      var pred = forward(models[kind], feats[kind], P);
+      var ps = imagePsnr(pred, target, P * 3);
+      var px = new Float32Array(P * 3);
+      for (var i = 0; i < P * 3; i++) px[i] = Math.max(0, Math.min(1, pred[i]));
+      drawPixels(cvs[kind], px, TW, TH);
+      tags[kind].innerHTML = "<b>" + ps.toFixed(1) + "</b> dB";
+      curves[kind].push([step, ps]);
+      lastEval[kind] = step;
+    }
+
+    var Xb = {}, Yb = new Float32Array(BATCH * 3);
+    function stepAll() {
+      /* one lockstep round: identical pixel minibatch for the three models */
+      var idx = [];
+      for (var n = 0; n < BATCH; n++) {
+        var p = (batchRng() * P) | 0;
+        idx.push(p);
+        Yb.set(target.subarray(p * 3, p * 3 + 3), n * 3);
+      }
+      KINDS.forEach(function (kind) {
+        var m = models[kind], D = m.inDim;
+        if (!Xb[kind] || Xb[kind].length < BATCH * D) Xb[kind] = new Float32Array(BATCH * D);
+        var xb = Xb[kind], f = feats[kind];
+        for (var n2 = 0; n2 < BATCH; n2++)
+          xb.set(f.subarray(idx[n2] * D, (idx[n2] + 1) * D), n2 * D);
+        trainStep(m, xb, Yb, BATCH, LRS[kind]);
+      });
+      step++;
+    }
+
+    var chart = document.getElementById("inr-race-chart");
+    var stepOut = document.getElementById("inr-race-step");
+    function drawChart() {
+      var W = 560, H = 280, L = 40, R = 14, T = 12, B = 28;
+      var ymin = 8, ymax = 36;
+      function px(s) { return L + s / MAX * (W - L - R); }
+      function py(p) { return T + (ymax - p) / (ymax - ymin) * (H - T - B); }
+      var s = "";
+      for (var g = ymin; g <= ymax; g += 4) {
+        s += '<line x1="' + L + '" y1="' + py(g) + '" x2="' + (W - R) + '" y2="' + py(g) + '" stroke="' + COL.grid + '"/>' +
+             '<text x="' + (L - 6) + '" y="' + (py(g) + 4) + '" font-size="10" text-anchor="end" fill="' + COL.muted + '">' + g + '</text>';
+      }
+      [0, 450, 900, 1350].forEach(function (t) {   /* no 1800 tick — the axis label sits there */
+        s += '<text x="' + px(t) + '" y="' + (H - 8) + '" font-size="10" text-anchor="middle" fill="' + COL.muted + '">' + t + '</text>';
+      });
+      s += '<text x="' + (L + 4) + '" y="' + (T + 10) + '" font-size="10" fill="' + COL.muted + '">PSNR (dB)</text>';
+      s += '<text x="' + (W - R) + '" y="' + (H - 8) + '" font-size="10" text-anchor="end" fill="' + COL.muted + '">step</text>';
+      var colOf = { relu: COL.warn, fourier: COL.accent, siren: COL.good };
+      KINDS.forEach(function (kind) {
+        var c = curves[kind];
+        if (!c || c.length < 2) return;
+        var pts = "";
+        for (var i = 0; i < c.length; i++)
+          pts += px(c[i][0]).toFixed(1) + "," + py(Math.max(ymin, Math.min(ymax, c[i][1]))).toFixed(1) + " ";
+        s += '<polyline points="' + pts + '" fill="none" stroke="' + colOf[kind] + '" stroke-width="2"/>';
+      });
+      chart.innerHTML = s;
+      stepOut.textContent = step;
+    }
+
+    var playBtn = document.getElementById("inr-race-play");
+    function frame() {
+      if (!running) return;
+      var t0 = performance.now();
+      while (performance.now() - t0 < 16 && step < MAX) stepAll();
+      /* stagger the (expensive) full-image evals: one model per frame */
+      var kind = KINDS[rot % 3]; rot++;
+      if (step - lastEval[kind] >= EVAL || step >= MAX) evalModel(kind);
+      drawChart();
+      if (step >= MAX) {
+        KINDS.forEach(function (kk) { if (lastEval[kk] < MAX) evalModel(kk); });
+        drawChart();
+        running = false; playBtn.textContent = "▶ train";
+        return;
+      }
+      requestAnimationFrame(frame);
+    }
+    playBtn.addEventListener("click", function () {
+      if (running) { running = false; playBtn.textContent = "▶ train"; return; }
+      if (step >= MAX) init();
+      running = true; playBtn.textContent = "❚❚ pause";
+      requestAnimationFrame(frame);
+    });
+    document.getElementById("inr-race-reset").addEventListener("click", function () {
+      running = false; playBtn.textContent = "▶ train"; init(); drawChart();
+    });
+    var sigSlider = document.getElementById("inr-race-sigma");
+    var sigOut = document.getElementById("inr-race-sigma-out");
+    sigSlider.addEventListener("input", function () {
+      sigma = +sigSlider.value;
+      sigOut.textContent = sigma;
+      /* rebuild only the Fourier model; its curve restarts from the current step */
+      buildModel("fourier");
+      models.fourier.t = 0;
+      evalModel("fourier");
+      drawChart();
+    });
+    redrawFns.push(drawChart);
+    init(); drawChart();
+  };
+
+  /* ================================================================
+     Demo 4: arbitrary-scale upscaling
+     ================================================================ */
+  var initSrDemo = function () {};
+  initSrDemo = function () {
+    var LW = 24, LH = 36, P = LW * LH, MAX = 1500, BATCH = 256, LR = 1e-3;
+    var low = areaDownsample(IMG.px, IMG.w, IMG.h, 4);
+    drawPixels(document.getElementById("inr-sr-low"), low, LW, LH);
+    var grid = makeGrid(LH, LW);
+    var model, step, running = false;
+    var batchRng = makeRng(7);
+    var Xb = new Float32Array(BATCH * 2), Yb = new Float32Array(BATCH * 3);
+
+    var prog = document.getElementById("inr-sr-prog");
+    var scaleSl = document.getElementById("inr-sr-scale");
+    var scaleOut = document.getElementById("inr-sr-scale-out");
+    var cvNear = document.getElementById("inr-sr-near");
+    var cvBic = document.getElementById("inr-sr-bic");
+    var cvInr = document.getElementById("inr-sr-inr");
+    var tagNear = document.getElementById("inr-sr-psnr-near");
+    var tagBic = document.getElementById("inr-sr-psnr-bic");
+    var tagInr = document.getElementById("inr-sr-psnr-inr");
+
+    function init() {
+      step = 0;
+      model = makeModel("siren", { width: 40, depth: 3, omega: 15, seed: 1 });
+      prog.textContent = "untrained";
+    }
+
+    function nearest(dw, dh) {
+      var out = new Float32Array(dw * dh * 3);
+      for (var r = 0; r < dh; r++) {
+        var sr = Math.min(LH - 1, Math.floor(r * LH / dh));
+        for (var c = 0; c < dw; c++) {
+          var sc = Math.min(LW - 1, Math.floor(c * LW / dw));
+          var si = (sr * LW + sc) * 3, di = (r * dw + c) * 3;
+          out[di] = low[si]; out[di + 1] = low[si + 1]; out[di + 2] = low[si + 2];
+        }
+      }
+      return out;
+    }
+    function cubicW(t) {  /* a = -0.75, PyTorch's bicubic kernel */
+      t = Math.abs(t);
+      if (t <= 1) return 1.25 * t * t * t - 2.25 * t * t + 1;
+      if (t < 2) return -0.75 * t * t * t + 3.75 * t * t - 6 * t + 3;
+      return 0;
+    }
+    function bicubic(dw, dh) {
+      var out = new Float32Array(dw * dh * 3);
+      for (var r = 0; r < dh; r++) {
+        var sy = (r + 0.5) * LH / dh - 0.5, y0 = Math.floor(sy);
+        for (var c = 0; c < dw; c++) {
+          var sx = (c + 0.5) * LW / dw - 0.5, x0 = Math.floor(sx);
+          var a0 = 0, a1 = 0, a2 = 0, wsum = 0;
+          for (var dy = -1; dy <= 2; dy++) for (var dx = -1; dx <= 2; dx++) {
+            var w = cubicW(sy - (y0 + dy)) * cubicW(sx - (x0 + dx));
+            if (!w) continue;
+            var yy = Math.min(LH - 1, Math.max(0, y0 + dy));
+            var xx = Math.min(LW - 1, Math.max(0, x0 + dx));
+            var i = (yy * LW + xx) * 3;
+            a0 += w * low[i]; a1 += w * low[i + 1]; a2 += w * low[i + 2]; wsum += w;
+          }
+          var o = (r * dw + c) * 3;
+          out[o] = Math.max(0, Math.min(1, a0 / wsum));
+          out[o + 1] = Math.max(0, Math.min(1, a1 / wsum));
+          out[o + 2] = Math.max(0, Math.min(1, a2 / wsum));
+        }
+      }
+      return out;
+    }
+    function renderInr(dw, dh) {
+      var g = makeGrid(dh, dw), n = dw * dh;
+      var pred = forward(model, g, n);
+      var out = new Float32Array(n * 3);
+      for (var i = 0; i < n * 3; i++) out[i] = Math.max(0, Math.min(1, pred[i]));
+      return out;
+    }
+    /* ground truth at the render size, when it divides the 96x144 original */
+    function groundTruth(dw, dh) {
+      if (dw === IMG.w && dh === IMG.h) return IMG.px;
+      if (IMG.w % dw === 0 && (IMG.w / dw) === (IMG.h / dh))
+        return areaDownsample(IMG.px, IMG.w, IMG.h, IMG.w / dw);
+      return null;
+    }
+
+    function renderAll() {
+      var s = +scaleSl.value;
+      scaleOut.textContent = "×" + s.toFixed(1);
+      var dw = Math.round(LW * s), dh = Math.round(LH * s);
+      var near = nearest(dw, dh), bic = bicubic(dw, dh), inr = renderInr(dw, dh);
+      drawPixels(cvNear, near, dw, dh);
+      drawPixels(cvBic, bic, dw, dh);
+      drawPixels(cvInr, inr, dw, dh);
+      var gt = groundTruth(dw, dh), label = dw + " × " + dh;
+      function tag(el, px) {
+        if (!gt) { el.textContent = label; return; }
+        var ps = imagePsnr(px, gt, dw * dh * 3);
+        el.innerHTML = ps > 55 ? label + " · exact" : label + " · <b>" + ps.toFixed(1) + "</b> dB";
+      }
+      tag(tagNear, near); tag(tagBic, bic); tag(tagInr, inr);
+    }
+
+    var playBtn = document.getElementById("inr-sr-play");
+    function frame() {
+      if (!running) return;
+      var t0 = performance.now();
+      while (performance.now() - t0 < 14 && step < MAX) {
+        for (var n = 0; n < BATCH; n++) {
+          var p = (batchRng() * P) | 0;
+          Xb[n * 2] = grid[p * 2]; Xb[n * 2 + 1] = grid[p * 2 + 1];
+          Yb.set(low.subarray(p * 3, p * 3 + 3), n * 3);
+        }
+        trainStep(model, Xb, Yb, BATCH, LR);
+        step++;
+      }
+      var pred = forward(model, grid, P);
+      prog.innerHTML = "step <span class='inr-readout'>" + step + "</span> / " + MAX +
+                       " · train fit " + imagePsnr(pred, low, P * 3).toFixed(1) + " dB";
+      if (step % 250 === 0 || step >= MAX) renderAll();
+      if (step >= MAX) { running = false; playBtn.textContent = "▶ fit the low-res image"; renderAll(); return; }
+      requestAnimationFrame(frame);
+    }
+    playBtn.addEventListener("click", function () {
+      if (running) { running = false; playBtn.textContent = "▶ fit the low-res image"; return; }
+      if (step >= MAX) init();
+      running = true; playBtn.textContent = "❚❚ pause";
+      requestAnimationFrame(frame);
+    });
+    document.getElementById("inr-sr-reset").addEventListener("click", function () {
+      running = false; playBtn.textContent = "▶ fit the low-res image"; init(); renderAll();
+    });
+    scaleSl.addEventListener("input", renderAll);
+    init(); renderAll();
+  };
+
+})();
+</script>
+
+</div>


### PR DESCRIPTION
Interactive companion to the implicit_neural_representations project in
data-science-stuff. Four demos, all vanilla JS on a tiny Float32Array
MLP engine (Adam, minibatch SGD) mirroring the PyTorch reference:

- hover the lighthouse to read off (coordinate, colour) training pairs
- 1-D spectral bias: ReLU vs Fourier-feature MLP fitting a 3-sine target,
  with per-frequency residual bars
- live training race on a 48x72 lighthouse: ReLU MLP vs random Fourier
  features (tunable sigma) vs SIREN, with PSNR curves
- arbitrary-scale upscaling: SIREN fitted to 24x36, rendered at any
  scale incl. non-integer, vs nearest/bicubic with PSNR at x2/x4

Target image is kodim19 (Kodak suite) embedded as a small JPEG data URI.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DsdhenGd7mpmMPLNaNwoDh