### PR TITLE
Add Snake AI mode with tabular Q-learning + companion study note

### DIFF
--- a/docs/_posts/2026-07-20-q-learning-snake.html
+++ b/docs/_posts/2026-07-20-q-learning-snake.html
@@ -1,0 +1,729 @@
+---
+layout: post
+title: "Tabular Q-Learning, Explained by a Snake"
+date: 2026-07-20
+categories: [Reinforcement Learning, Interactive]
+excerpt: "Q-learning estimates the value of every action in every state directly from experience, with no model of the environment. These notes work through the tabular version end to end — state design, reward shaping, the temporal-difference update, and ε-greedy exploration — using the Snake agent from this site's game page as the running example, retrained from scratch in a live demo."
+---
+
+{% include study-note-styles.html %}
+
+<div class="study-note">
+
+<style>
+/* Note-specific layout only — colors come from tokens, shared components
+   come from study-note-styles.html. */
+.ql-controls { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin: 0.75rem 0; }
+
+.ql-boardwrap { text-align: center; }
+.ql-boardwrap svg, .ql-boardwrap canvas {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--sn-border);
+  border-radius: var(--sn-radius-sm);
+  background: var(--sn-panel);
+  display: inline-block;
+}
+
+.ql-statebits { display: flex; gap: 0.5rem 0.75rem; flex-wrap: wrap; align-items: center; margin: 0.75rem 0 0.4rem; }
+.ql-bit { display: flex; flex-direction: column; gap: 0.2rem; align-items: flex-start; }
+.ql-bit .blabel { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; font-weight: 700; }
+.ql-key {
+  font-family: var(--sn-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+  color: var(--sn-accent);
+  background: var(--sn-panel);
+  border: 1px solid var(--sn-accent-line);
+  border-radius: var(--sn-radius-sm);
+  padding: 0.5rem 0.8rem;
+  display: inline-block;
+  margin-top: 0.5rem;
+}
+
+.ql-calcgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 1rem; align-items: start; }
+.ql-scenario { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.ql-scn {
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--sn-radius-sm);
+  border: 1px solid var(--sn-border);
+  background: var(--sn-panel-inset);
+  color: var(--sn-text);
+  font-size: 0.88rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s var(--sn-ease);
+}
+.ql-scn:hover { border-color: var(--sn-accent-line); }
+.ql-scn.active { background: var(--sn-accent); color: var(--sn-on-accent); border-color: var(--sn-accent); }
+.ql-sliderrow { display: flex; align-items: center; gap: 0.6rem; margin: 0.5rem 0; font-size: 0.88rem; }
+.ql-sliderrow input[type="range"] { flex: 1; min-width: 120px; }
+.ql-calc {
+  font-family: var(--sn-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.88rem;
+  line-height: 1.9;
+  background: var(--sn-panel);
+  border: 1px solid var(--sn-border);
+  border-radius: var(--sn-radius-sm);
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+}
+.ql-calc .hl { color: var(--sn-accent); font-weight: 700; }
+.ql-calc .dim { color: var(--sn-muted); }
+
+.ql-stats { display: flex; gap: 1.4rem; flex-wrap: wrap; justify-content: center; margin: 0.75rem 0 0.25rem; }
+.se-stat { text-align: center; }
+.se-stat .val { font-size: 1.45rem; }
+.se-stat .lab { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; font-weight: 700; }
+
+.ql-rewards { width: 100%; border-collapse: collapse; font-size: 0.88rem; margin: 0.75rem 0; }
+.ql-rewards th, .ql-rewards td { padding: 0.45rem 0.65rem; border: 1px solid var(--sn-border); text-align: left; }
+.ql-rewards th { background: var(--sn-panel-inset); font-weight: 600; }
+.ql-rewards td.num { font-family: var(--sn-mono); font-variant-numeric: tabular-nums; text-align: center; font-weight: 700; }
+.ql-rewards td.pos { color: var(--sn-good); }
+.ql-rewards td.neg { color: var(--sn-bad); }
+
+.ql-epslabel { font-size: 0.85rem; opacity: 0.7; margin-top: 0.4rem; }
+</style>
+
+<p>
+  <strong>Q-learning</strong> is a model-free reinforcement-learning algorithm: it learns the value of taking each action in each state purely from experienced transitions, without ever knowing the environment's dynamics. The <em>tabular</em> version stores those values in a literal lookup table Q(s,&nbsp;a) and improves them with a one-line temporal-difference update after every single step. The interesting engineering is not the update — it is everything around it: how the state is encoded, how the reward is shaped, and how exploration is scheduled.
+</p>
+
+<div class="se-note">
+  <strong>In one sentence:</strong> after every step, nudge the stored value of the action just taken toward <em>reward received + discounted value of the best action available next</em> — do this enough times, under enough exploration, and the table converges to the values of optimal play.
+</div>
+
+<p>
+  The running example throughout is the Snake agent from this site's <a href="/game/">game page</a>: a snake on a 20×20 grid that must eat food without hitting the walls or its own body. It is a good test case precisely because the naive formulation is hopeless — the raw board has more configurations than atoms in the universe — so every design decision below is forced, not decorative. The final section retrains the same agent from scratch on a smaller board, inside this page.
+</p>
+
+<!-- ==================== STATE ==================== -->
+<div class="se-section">
+  <h3>🧭 What the snake actually sees</h3>
+  <p style="margin-top:0">
+    A tabular method must visit each state many times to learn its values, so the state space has to be tiny. The full board is out: even a modest 20×20 grid has on the order of 10<sup>100</sup> snake configurations. The fix is to describe the situation <em>relative to the snake's head</em>, keeping only what matters for the immediate decision:
+  </p>
+  <ul>
+    <li><strong>Danger bits (3):</strong> would moving straight, turning left, or turning right cause a collision on the very next step?</li>
+    <li><strong>Heading (4):</strong> up, right, down, or left.</li>
+    <li><strong>Food direction (9):</strong> the <em>signs</em> of the food's horizontal and vertical offset from the head — not the distance, just which way.</li>
+  </ul>
+  <p>
+    That is 2³ × 4 × 9 = <strong>288 possible states</strong> (fewer in practice, since some combinations never occur — the trained agent on the game page visits about 250). Actions are relative too: <strong>turn left, go straight, turn right</strong>. With only relative turns available, reversing into the own neck is not even expressible, which removes an entire class of instant deaths from the learning problem.
+  </p>
+  <p>
+    Drive the snake below with the three relative actions and watch the state it perceives. Click any cell to move the food. Note how radically different board positions collapse into the same state key — that collapsing is what makes the table small enough to learn.
+  </p>
+
+  <div class="ql-controls" style="justify-content:center">
+    <button class="se-btn sec" id="enc-left">↰ Turn left</button>
+    <button class="se-btn" id="enc-straight">↑ Straight</button>
+    <button class="se-btn sec" id="enc-right">↱ Turn right</button>
+    <button class="reset-link" id="enc-reset">↺ Reset</button>
+  </div>
+
+  <div class="ql-boardwrap">
+    <svg id="enc-svg" width="330" height="330" viewBox="0 0 286 286"></svg>
+  </div>
+
+  <div class="ql-statebits" id="enc-bits"></div>
+  <div class="ql-key" id="enc-key"></div>
+  <p style="font-size:0.8rem;opacity:0.65;margin-bottom:0">
+    The highlighted cells are the agent's entire sensory field: the square straight ahead (S), to its left (L), and to its right (R). Everything else on the board — including most of its own body — is invisible to it.
+  </p>
+</div>
+
+<!-- ==================== REWARDS ==================== -->
+<div class="se-section">
+  <h3>🍎 Rewards, and why shaping is asymmetric</h3>
+  <p style="margin-top:0">
+    The reward function defines the task. Eating and dying are the obvious signals, but on their own they are too sparse: a random snake takes hundreds of steps to stumble into its first food, and until then every action looks equally worthless. A small <em>shaping</em> reward based on Manhattan distance to the food gives the agent a gradient to follow from step one.
+  </p>
+
+  <table class="ql-rewards">
+    <tr><th>Event</th><th style="text-align:center">Reward</th><th>Purpose</th></tr>
+    <tr><td>Eats the food</td><td class="num pos">+10</td><td>the actual objective</td></tr>
+    <tr><td>Hits a wall or its body</td><td class="num neg">−10</td><td>terminal; ends the episode</td></tr>
+    <tr><td>Too many steps without eating</td><td class="num neg">−10</td><td>starvation cutoff — stops endless wandering episodes</td></tr>
+    <tr><td>Step that moves closer to food</td><td class="num pos">+0.3</td><td>shaping: dense progress signal</td></tr>
+    <tr><td>Step that moves away from food</td><td class="num neg">−0.45</td><td>shaping, deliberately larger — see below</td></tr>
+  </table>
+
+  <p>
+    The asymmetry between +0.3 and −0.45 is not an accident. With symmetric shaping (+0.3 / −0.3), a snake that circles forever near the food breaks even on shaping and never risks the −10 of a crash — so cowardly orbiting becomes a decent policy, and early training gets stuck in it. Making retreat cost 1.5× what approach earns turns any closed loop into a strict net loss: every circle contains equally many approaching and retreating steps, so circling bleeds value and the only way to profit is to actually reach the food.
+  </p>
+  <div class="se-note">
+    Shaping rewards are a scalpel, not free guidance: any shaping term the agent can farm without solving the task <em>will</em> be farmed. The safe question to ask of each term is "what degenerate policy does this make profitable?"
+  </div>
+</div>
+
+<!-- ==================== UPDATE RULE ==================== -->
+<div class="se-section">
+  <h3>📐 The temporal-difference update</h3>
+  <p style="margin-top:0">
+    Q(s,&nbsp;a) estimates the total discounted reward from taking action <em>a</em> in state <em>s</em> and acting optimally afterwards. After each transition (s, a, r, s′) the table is nudged toward a better estimate of itself:
+  </p>
+  <div class="se-equation">
+    Q(s,a) &larr; Q(s,a) + &alpha; [ r + &gamma; &middot; max<sub>a'</sub> Q(s',a') &minus; Q(s,a) ]
+  </div>
+  <p>
+    The bracket is the <strong>TD error</strong>: the gap between what the table predicted, Q(s,a), and the fresher one-step estimate <em>r + γ·max Q(s′,·)</em> — one real reward plus the table's own best guess about the future. The learning rate α controls how far each nudge goes; the discount γ controls how much the future is worth relative to the present. When the transition is terminal (a crash), there is no future: the target is just <em>r</em>.
+  </p>
+  <p>
+    Pick a scenario and drag the sliders to see one concrete update. The snake is in some state s with stored values Q(s,·) = [1.2, <strong>2.4</strong>, −0.5] for [left, straight, right], it goes <strong>straight</strong>, and the best action in the resulting state s′ is worth 4.6.
+  </p>
+
+  <div class="ql-calcgrid">
+    <div>
+      <div class="ql-scenario" id="calc-scenarios"></div>
+      <div class="ql-sliderrow">
+        <span style="width:9.5em">learning rate &alpha; = <span class="se-readout" id="calc-alpha-out">0.15</span></span>
+        <input type="range" id="calc-alpha" min="1" max="100" value="15">
+      </div>
+      <div class="ql-sliderrow">
+        <span style="width:9.5em">discount &gamma; = <span class="se-readout" id="calc-gamma-out">0.90</span></span>
+        <input type="range" id="calc-gamma" min="0" max="100" value="90">
+      </div>
+    </div>
+    <div class="ql-calc" id="calc-out"></div>
+  </div>
+
+  <p style="margin-top:1rem">
+    Two things worth internalizing from playing with it. First, the crash update ignores γ entirely — death has no future to discount, which is why terminal states anchor the whole table: their −10 is ground truth, and it propagates backwards through the max. Second, α is a compromise: at α = 1 each update overwrites the cell with a noisy one-sample estimate; at α → 0 learning stalls. The agent on the game page uses α = 0.15, γ = 0.9.
+  </p>
+</div>
+
+<!-- ==================== EPSILON ==================== -->
+<div class="se-section">
+  <h3>🎲 ε-greedy exploration, on a schedule</h3>
+  <p style="margin-top:0">
+    A greedy agent exploits whatever the half-learned table currently says and can lock into bad habits before ever trying the better move. The standard fix is <strong>ε-greedy</strong>: with probability ε act uniformly at random, otherwise take the argmax action. Crucially, ε is <em>scheduled</em>: it starts at 1.0 (pure random exploration, since the initial table knows nothing worth exploiting) and decays multiplicatively after every episode — ε &larr; max(ε<sub>min</sub>, ε &middot; d) — down to a floor of 0.01 that keeps a sliver of lifelong exploration.
+  </p>
+  <p>
+    Drag the slider to see how the decay constant d shapes the schedule over the first 1000 episodes.
+  </p>
+
+  <div class="ql-sliderrow" style="max-width:460px">
+    <span style="width:11em">decay d = <span class="se-readout" id="eps-decay-out">0.995</span></span>
+    <input type="range" id="eps-decay" min="900" max="999" value="995">
+  </div>
+  <div class="ql-boardwrap" style="text-align:left">
+    <canvas id="eps-canvas" width="460" height="150"></canvas>
+  </div>
+  <div class="ql-epslabel" id="eps-label"></div>
+
+  <p style="margin-top:1rem">
+    The schedule has to match the state space. With ~288 states and 3 actions there are under a thousand table cells, and episodes are short early on, so d = 0.995 (mostly greedy after roughly 500 episodes — under a minute of fast training) is enough to cover the table. A big state space with the same schedule would go greedy long before exploration had touched most of it.
+  </p>
+</div>
+
+<!-- ==================== LIVE TRAINER ==================== -->
+<div class="se-section">
+  <h3>🐍 The full loop, from scratch</h3>
+  <p style="margin-top:0">
+    All four pieces — relative state, shaped rewards, TD updates, decaying ε — assembled into the complete algorithm, running here on a 12×12 board with a fresh, empty table. Press <strong>Start</strong> and switch to fast mode: the early episodes are near-random flailing, then the shaping gradient kicks in, then food-seeking becomes reliable and the rolling average climbs. The curve is the whole story of the algorithm compressed into one line.
+  </p>
+
+  <div class="ql-controls" style="justify-content:center">
+    <button class="se-btn" id="tr-start">▶ Start training</button>
+    <button class="se-btn sec" id="tr-speed1">1×</button>
+    <button class="se-btn sec" id="tr-speed200">200×</button>
+    <button class="reset-link" id="tr-reset">↺ Reset table</button>
+  </div>
+
+  <div class="ql-boardwrap">
+    <canvas id="tr-board" width="264" height="264"></canvas>
+  </div>
+
+  <div class="ql-stats">
+    <div class="se-stat"><div class="val" id="tr-episodes">0</div><div class="lab">Episodes</div></div>
+    <div class="se-stat"><div class="val" id="tr-last">–</div><div class="lab">Last score</div></div>
+    <div class="se-stat"><div class="val" id="tr-best">0</div><div class="lab">Best</div></div>
+    <div class="se-stat"><div class="val" id="tr-avg">–</div><div class="lab">Avg (50)</div></div>
+    <div class="se-stat"><div class="val" id="tr-eps">1.00</div><div class="lab">ε</div></div>
+    <div class="se-stat"><div class="val" id="tr-states">0</div><div class="lab">States seen</div></div>
+  </div>
+
+  <div class="ql-boardwrap" style="text-align:left">
+    <canvas id="tr-curve" width="460" height="130"></canvas>
+  </div>
+  <p style="font-size:0.8rem;opacity:0.65;margin-bottom:0">
+    Score = food eaten per episode. Thin line: raw episodes. Thick line: 20-episode rolling average. The table lives only on this page — reload and it forgets.
+  </p>
+</div>
+
+<p>
+  A few hundred numbers in a lookup table, one line of arithmetic per step, and no knowledge of the rules of Snake beyond what the reward says — that is the entire algorithm. Its limits are equally visible: the relative state cannot see the body's global layout, so the learned policy still traps itself inside its own coils at high scores, and no amount of further training fixes what the state cannot represent. Fixing <em>that</em> is where function approximation and deep Q-networks come in. The persistent version of this agent — same state, same rewards, same update, on the full 20×20 board with its table saved in the browser — lives on the <a href="/game/">game page</a>.
+</p>
+
+<script>
+(function () {
+  "use strict";
+
+  /* ---- shared theme plumbing (pattern from the authoring guide) ---- */
+  const SN = document.querySelector(".study-note");
+  const readCols = () => {
+    const cs = getComputedStyle(SN);
+    const c = n => cs.getPropertyValue(n).trim();
+    return {
+      accent: c("--sn-accent"), accentStrong: c("--sn-accent-strong"),
+      accentSoft: c("--sn-accent-soft"), accentLine: c("--sn-accent-line"),
+      good: c("--sn-good"), bad: c("--sn-bad"), badBg: c("--sn-bad-bg"),
+      warn: c("--sn-warn"), muted: c("--sn-muted"), grid: c("--sn-grid"),
+      panel: c("--sn-panel"), inset: c("--sn-panel-inset"), text: c("--sn-text")
+    };
+  };
+  let COL = readCols();
+  const redrawFns = [];
+  const onTheme = fn => { redrawFns.push(fn); return fn; };
+  new MutationObserver(() => { COL = readCols(); redrawFns.forEach(f => f()); })
+    .observe(document.body, { attributes: true, attributeFilter: ["class"] });
+
+  const DIRS = ["up", "right", "down", "left"];
+  const DELTA = { up: [0, -1], right: [1, 0], down: [0, 1], left: [-1, 0] };
+  const ARROW = { up: "↑", right: "→", down: "↓", left: "←" };
+  const turnDir = (dir, action) => {
+    const i = DIRS.indexOf(dir);
+    if (action === 0) return DIRS[(i + 3) % 4]; // left
+    if (action === 2) return DIRS[(i + 1) % 4]; // right
+    return dir;
+  };
+  const sgn = v => (v > 0 ? 1 : v < 0 ? -1 : 0);
+
+  /* ============================================================
+     Demo 1 — state encoder: drive the snake, see its state
+     ============================================================ */
+  (function encoder() {
+    const G = 11, CELL = 26, SVGNS = "http://www.w3.org/2000/svg";
+    const svg = document.getElementById("enc-svg");
+    const bitsEl = document.getElementById("enc-bits");
+    const keyEl = document.getElementById("enc-key");
+
+    let snake, dir, food, crashed;
+    const reset = () => {
+      snake = [{ x: 5, y: 5 }, { x: 4, y: 5 }, { x: 3, y: 5 }, { x: 2, y: 5 }];
+      dir = "right"; food = { x: 8, y: 3 }; crashed = false;
+    };
+    reset();
+
+    const el = (tag, attrs) => {
+      const e = document.createElementNS(SVGNS, tag);
+      for (const k in attrs) e.setAttribute(k, attrs[k]);
+      return e;
+    };
+    const collides = c =>
+      c.x < 0 || c.y < 0 || c.x >= G || c.y >= G ||
+      snake.some(s => s.x === c.x && s.y === c.y);
+    const ahead = (from, d) => ({ x: from.x + DELTA[d][0], y: from.y + DELTA[d][1] });
+
+    const sense = () => {
+      const head = snake[0];
+      const cells = {
+        S: ahead(head, dir),
+        L: ahead(head, turnDir(dir, 0)),
+        R: ahead(head, turnDir(dir, 2))
+      };
+      return {
+        cells,
+        danger: { S: collides(cells.S), L: collides(cells.L), R: collides(cells.R) },
+        fx: sgn(food.x - head.x),
+        fy: sgn(food.y - head.y)
+      };
+    };
+
+    function draw() {
+      while (svg.firstChild) svg.removeChild(svg.firstChild);
+      // grid + click targets
+      for (let y = 0; y < G; y++) for (let x = 0; x < G; x++) {
+        const r = el("rect", {
+          x: x * CELL, y: y * CELL, width: CELL, height: CELL,
+          fill: "transparent", stroke: COL.grid, "stroke-width": 0.5
+        });
+        r.style.cursor = "pointer";
+        r.addEventListener("click", () => {
+          if (!snake.some(s => s.x === x && s.y === y)) { food = { x: x, y: y }; render(); }
+        });
+        svg.appendChild(r);
+      }
+      // sensed cells
+      const s = sense();
+      for (const k of ["S", "L", "R"]) {
+        const c = s.cells[k], danger = s.danger[k];
+        if (c.x >= 0 && c.y >= 0 && c.x < G && c.y < G) {
+          svg.appendChild(el("rect", {
+            x: c.x * CELL + 1, y: c.y * CELL + 1, width: CELL - 2, height: CELL - 2,
+            fill: danger ? COL.badBg : COL.accentSoft, rx: 3,
+            stroke: danger ? COL.bad : COL.accentLine, "stroke-width": 1.5
+          }));
+        }
+        const tx = Math.min(Math.max(c.x, 0), G - 1) * CELL + CELL / 2;
+        const ty = Math.min(Math.max(c.y, 0), G - 1) * CELL + CELL / 2 + 4;
+        const t = el("text", { x: tx, y: ty, "text-anchor": "middle", "font-size": 11, "font-weight": 700 });
+        t.setAttribute("fill", danger ? COL.bad : COL.accent);
+        t.textContent = k;
+        svg.appendChild(t);
+      }
+      // food
+      svg.appendChild(el("circle", {
+        cx: food.x * CELL + CELL / 2, cy: food.y * CELL + CELL / 2,
+        r: CELL * 0.32, fill: COL.bad
+      }));
+      // snake
+      snake.forEach((c, i) => {
+        svg.appendChild(el("rect", {
+          x: c.x * CELL + 2, y: c.y * CELL + 2, width: CELL - 4, height: CELL - 4,
+          rx: 4, fill: i === 0 ? COL.accentStrong : COL.accent,
+          opacity: i === 0 ? 1 : 0.85
+        }));
+      });
+      // heading arrow on the head
+      const h = snake[0];
+      const t = el("text", {
+        x: h.x * CELL + CELL / 2, y: h.y * CELL + CELL / 2 + 4.5,
+        "text-anchor": "middle", "font-size": 13, "font-weight": 700
+      });
+      t.setAttribute("fill", COL.panel);
+      t.textContent = ARROW[dir];
+      svg.appendChild(t);
+      // border, flashes on crash
+      svg.appendChild(el("rect", {
+        x: 0.5, y: 0.5, width: G * CELL - 1, height: G * CELL - 1,
+        fill: "none", stroke: crashed ? COL.bad : COL.grid, "stroke-width": crashed ? 2.5 : 1
+      }));
+    }
+
+    const tag = (label, text, cls) =>
+      '<div class="ql-bit"><span class="blabel">' + label + '</span>' +
+      '<span class="se-tag ' + cls + '">' + text + "</span></div>";
+    const FOOD_TXT = { "-1": "−1", 0: "0", 1: "+1" };
+
+    function render() {
+      draw();
+      const s = sense();
+      bitsEl.innerHTML =
+        tag("danger straight", s.danger.S ? "1 · danger" : "0 · safe", s.danger.S ? "hot" : "good") +
+        tag("danger left", s.danger.L ? "1 · danger" : "0 · safe", s.danger.L ? "hot" : "good") +
+        tag("danger right", s.danger.R ? "1 · danger" : "0 · safe", s.danger.R ? "hot" : "good") +
+        tag("heading", ARROW[dir] + " " + dir, "") +
+        tag("food Δx sign", FOOD_TXT[s.fx], "warn") +
+        tag("food Δy sign", FOOD_TXT[s.fy], "warn");
+      keyEl.textContent = "state = " +
+        (s.danger.S ? 1 : 0) + "" + (s.danger.L ? 1 : 0) + (s.danger.R ? 1 : 0) +
+        "|" + dir + "|" + s.fx + "," + s.fy + "   — 1 of 288";
+    }
+
+    function step(action) {
+      if (crashed) return;
+      dir = turnDir(dir, action);
+      const next = ahead(snake[0], dir);
+      if (collides(next)) {
+        crashed = true; render();
+        setTimeout(() => { reset(); render(); }, 650);
+        return;
+      }
+      snake.pop(); snake.unshift(next);
+      if (next.x === food.x && next.y === food.y) food = { x: 8, y: 3 };
+      render();
+    }
+
+    document.getElementById("enc-left").addEventListener("click", () => step(0));
+    document.getElementById("enc-straight").addEventListener("click", () => step(1));
+    document.getElementById("enc-right").addEventListener("click", () => step(2));
+    document.getElementById("enc-reset").addEventListener("click", () => { reset(); render(); });
+    onTheme(render);
+    render();
+  })();
+
+  /* ============================================================
+     Demo 2 — one TD update, worked
+     ============================================================ */
+  (function calculator() {
+    const SCN = [
+      { id: "eat", label: "🍎 Ate the food", r: 10, done: false },
+      { id: "closer", label: "↗ Moved closer", r: 0.3, done: false },
+      { id: "farther", label: "↘ Moved away", r: -0.45, done: false },
+      { id: "die", label: "💥 Crashed", r: -10, done: true }
+    ];
+    const Q_SA = 2.4, MAX_NEXT = 4.6;
+    let scn = SCN[0];
+
+    const wrap = document.getElementById("calc-scenarios");
+    const out = document.getElementById("calc-out");
+    const aIn = document.getElementById("calc-alpha"), aOut = document.getElementById("calc-alpha-out");
+    const gIn = document.getElementById("calc-gamma"), gOut = document.getElementById("calc-gamma-out");
+
+    SCN.forEach(s => {
+      const b = document.createElement("button");
+      b.className = "ql-scn" + (s === scn ? " active" : "");
+      b.textContent = s.label;
+      b.addEventListener("click", () => {
+        scn = s;
+        wrap.querySelectorAll(".ql-scn").forEach(x => x.classList.remove("active"));
+        b.classList.add("active");
+        render();
+      });
+      wrap.appendChild(b);
+    });
+
+    const f = (v, d) => (v < 0 ? "−" : "") + Math.abs(v).toFixed(d === undefined ? 2 : d);
+    function render() {
+      const alpha = aIn.value / 100, gamma = gIn.value / 100;
+      aOut.textContent = alpha.toFixed(2);
+      gOut.textContent = gamma.toFixed(2);
+      const target = scn.done ? scn.r : scn.r + gamma * MAX_NEXT;
+      const err = target - Q_SA;
+      const q2 = Q_SA + alpha * err;
+      out.innerHTML =
+        '<span class="dim">r = ' + f(scn.r) + (scn.done
+          ? ' · terminal</span><br>target = r = <span class="hl">' + f(target) + "</span><br>"
+          : "</span><br>target = " + f(scn.r) + " + " + gamma.toFixed(2) + " × " + f(MAX_NEXT) +
+            ' = <span class="hl">' + f(target) + "</span><br>") +
+        "TD error = " + f(target) + " − " + f(Q_SA) + ' = <span class="hl">' + f(err) + "</span><br>" +
+        "Q(s,straight) = " + f(Q_SA) + " + " + alpha.toFixed(2) + " × " + f(err) +
+        ' = <span class="hl">' + f(q2, 3) + "</span>";
+    }
+    aIn.addEventListener("input", render);
+    gIn.addEventListener("input", render);
+    render();
+  })();
+
+  /* ============================================================
+     Demo 3 — ε decay schedule
+     ============================================================ */
+  (function epsilon() {
+    const cv = document.getElementById("eps-canvas"), ctx = cv.getContext("2d");
+    const dIn = document.getElementById("eps-decay"), dOut = document.getElementById("eps-decay-out");
+    const label = document.getElementById("eps-label");
+    const EPS_MIN = 0.01, EPISODES = 1000;
+    const PADL = 34, PADB = 22, PADT = 10, PADR = 8;
+
+    function draw() {
+      const d = dIn.value / 1000;
+      dOut.textContent = d.toFixed(3);
+      const W = cv.width, H = cv.height;
+      const px = ep => PADL + (ep / EPISODES) * (W - PADL - PADR);
+      const py = e => PADT + (1 - e) * (H - PADT - PADB);
+      ctx.clearRect(0, 0, W, H);
+      // axes + gridlines
+      ctx.strokeStyle = COL.grid; ctx.lineWidth = 1;
+      ctx.font = "10px " + getComputedStyle(SN).getPropertyValue("--sn-mono");
+      ctx.fillStyle = COL.muted;
+      [0, 0.5, 1].forEach(v => {
+        ctx.beginPath(); ctx.moveTo(PADL, py(v)); ctx.lineTo(W - PADR, py(v)); ctx.stroke();
+        ctx.fillText(v.toFixed(1), 6, py(v) + 3);
+      });
+      [0, 250, 500, 750, 1000].forEach(ep => ctx.fillText(String(ep), px(ep) - 8, H - 6));
+      // curve
+      let cross = null, e = 1;
+      ctx.strokeStyle = COL.accent; ctx.lineWidth = 2;
+      ctx.beginPath();
+      for (let ep = 0; ep <= EPISODES; ep++) {
+        if (ep) e = Math.max(EPS_MIN, e * d);
+        if (cross === null && e < 0.1) cross = ep;
+        ep ? ctx.lineTo(px(ep), py(e)) : ctx.moveTo(px(ep), py(e));
+      }
+      ctx.stroke();
+      // mark the ε < 0.1 crossing
+      if (cross !== null) {
+        ctx.strokeStyle = COL.warn; ctx.setLineDash([4, 4]);
+        ctx.beginPath(); ctx.moveTo(px(cross), PADT); ctx.lineTo(px(cross), H - PADB); ctx.stroke();
+        ctx.setLineDash([]);
+        label.innerHTML = "ε drops below 0.1 (90% greedy) after <strong>" + cross +
+          "</strong> episodes; the floor ε = 0.01 keeps 1 step in 100 exploratory forever.";
+      } else {
+        label.textContent = "ε never drops below 0.1 within 1000 episodes at this decay rate.";
+      }
+    }
+    dIn.addEventListener("input", draw);
+    onTheme(draw);
+    draw();
+  })();
+
+  /* ============================================================
+     Demo 4 — live trainer: full Q-learning on a 12×12 board
+     ============================================================ */
+  (function trainer() {
+    const G = 12, CELL = 22;
+    const board = document.getElementById("tr-board"), bctx = board.getContext("2d");
+    const curve = document.getElementById("tr-curve"), cctx = curve.getContext("2d");
+    const $ = id => document.getElementById(id);
+    const startBtn = $("tr-start"), s1 = $("tr-speed1"), s200 = $("tr-speed200");
+
+    const ALPHA = 0.15, GAMMA = 0.9, EPS_MIN = 0.01, EPS_DECAY = 0.995;
+    const STARVE = 120, HISTORY_MAX = 300, BASE_SPS = 8;
+
+    let q, epsilon, episodes, best, history;
+    let snake, dir, food, score, sinceFood;
+    let running = false, speed = 1, carry = 0, lastTs = 0, drawnEpisodes = -1;
+
+    const resetTable = () => { q = {}; epsilon = 1; episodes = 0; best = 0; history = []; };
+    const collides = (c, body) =>
+      c.x < 0 || c.y < 0 || c.x >= G || c.y >= G ||
+      body.some(s => s.x === c.x && s.y === c.y);
+    const ahead = (from, d) => ({ x: from.x + DELTA[d][0], y: from.y + DELTA[d][1] });
+    const placeFood = () => {
+      let f;
+      do { f = { x: (Math.random() * G) | 0, y: (Math.random() * G) | 0 }; }
+      while (snake.some(s => s.x === f.x && s.y === f.y));
+      food = f;
+    };
+    const resetBoard = () => {
+      snake = [{ x: 6, y: 6 }, { x: 5, y: 6 }, { x: 4, y: 6 }];
+      dir = "right"; score = 0; sinceFood = 0; placeFood();
+    };
+
+    const stateKey = () => {
+      const h = snake[0];
+      const dS = collides(ahead(h, dir), snake) ? 1 : 0;
+      const dL = collides(ahead(h, turnDir(dir, 0)), snake) ? 1 : 0;
+      const dR = collides(ahead(h, turnDir(dir, 2)), snake) ? 1 : 0;
+      return dS + "" + dL + dR + "|" + dir + "|" + sgn(food.x - h.x) + "," + sgn(food.y - h.y);
+    };
+    const getQ = s => q[s] || (q[s] = [0, 0, 0]);
+
+    function step() {
+      const s = stateKey(), qs = getQ(s);
+      const a = Math.random() < epsilon
+        ? (Math.random() * 3) | 0
+        : qs.indexOf(Math.max(qs[0], qs[1], qs[2]));
+      dir = turnDir(dir, a);
+      const head = snake[0], next = ahead(head, dir);
+      const distBefore = Math.abs(food.x - head.x) + Math.abs(food.y - head.y);
+
+      let r, done = false;
+      if (collides(next, snake)) { r = -10; done = true; }
+      else {
+        snake.unshift(next);
+        if (next.x === food.x && next.y === food.y) {
+          r = 10; score++; sinceFood = 0; placeFood();
+        } else {
+          snake.pop();
+          sinceFood++;
+          if (sinceFood > STARVE) { r = -10; done = true; }
+          else {
+            const distAfter = Math.abs(food.x - next.x) + Math.abs(food.y - next.y);
+            r = distAfter < distBefore ? 0.3 : -0.45;
+          }
+        }
+      }
+      const target = done ? r : r + GAMMA * Math.max.apply(null, getQ(stateKey()));
+      qs[a] += ALPHA * (target - qs[a]);
+      if (done) {
+        history.push(score);
+        if (history.length > HISTORY_MAX) history.shift();
+        if (score > best) best = score;
+        episodes++;
+        epsilon = Math.max(EPS_MIN, epsilon * EPS_DECAY);
+        resetBoard();
+      }
+    }
+
+    function drawBoard() {
+      bctx.fillStyle = COL.inset;
+      bctx.fillRect(0, 0, board.width, board.height);
+      bctx.fillStyle = COL.bad;
+      bctx.beginPath();
+      bctx.arc(food.x * CELL + CELL / 2, food.y * CELL + CELL / 2, CELL * 0.32, 0, Math.PI * 2);
+      bctx.fill();
+      snake.forEach((c, i) => {
+        bctx.fillStyle = i === 0 ? COL.accentStrong : COL.accent;
+        bctx.fillRect(c.x * CELL + 1, c.y * CELL + 1, CELL - 2, CELL - 2);
+      });
+    }
+
+    function drawCurve() {
+      const W = curve.width, H = curve.height, PADL = 26, PADB = 4, PADT = 8, PADR = 6;
+      cctx.clearRect(0, 0, W, H);
+      cctx.font = "10px " + getComputedStyle(SN).getPropertyValue("--sn-mono");
+      if (history.length < 2) {
+        cctx.fillStyle = COL.muted;
+        cctx.fillText("score per episode appears here once training starts", PADL, H / 2);
+        return;
+      }
+      const max = Math.max(best, 1);
+      const px = i => PADL + (i / (history.length - 1)) * (W - PADL - PADR);
+      const py = v => PADT + (1 - v / max) * (H - PADT - PADB);
+      // best-score gridline
+      cctx.strokeStyle = COL.grid; cctx.setLineDash([3, 4]);
+      cctx.beginPath(); cctx.moveTo(PADL, py(best)); cctx.lineTo(W - PADR, py(best)); cctx.stroke();
+      cctx.setLineDash([]);
+      cctx.fillStyle = COL.muted;
+      cctx.fillText(String(best), 4, py(best) + 3);
+      cctx.fillText("0", 4, py(0) + 3);
+      // raw scores
+      cctx.strokeStyle = COL.accentLine; cctx.lineWidth = 1;
+      cctx.beginPath();
+      history.forEach((v, i) => i ? cctx.lineTo(px(i), py(v)) : cctx.moveTo(px(i), py(v)));
+      cctx.stroke();
+      // rolling average (20)
+      cctx.strokeStyle = COL.accent; cctx.lineWidth = 2;
+      cctx.beginPath();
+      let sum = 0;
+      const win = [];
+      history.forEach((v, i) => {
+        win.push(v); sum += v;
+        if (win.length > 20) sum -= win.shift();
+        const m = sum / win.length;
+        i ? cctx.lineTo(px(i), py(m)) : cctx.moveTo(px(i), py(m));
+      });
+      cctx.stroke();
+    }
+
+    function drawStats() {
+      $("tr-episodes").textContent = episodes;
+      $("tr-last").textContent = history.length ? history[history.length - 1] : "–";
+      $("tr-best").textContent = best;
+      const tail = history.slice(-50);
+      $("tr-avg").textContent = tail.length
+        ? (tail.reduce((a, b) => a + b, 0) / tail.length).toFixed(1) : "–";
+      $("tr-eps").textContent = epsilon.toFixed(2);
+      $("tr-states").textContent = Object.keys(q).length;
+    }
+
+    function frame(ts) {
+      if (!running) return;
+      const dt = Math.min(ts - lastTs, 250);
+      lastTs = ts;
+      carry += (dt / 1000) * BASE_SPS * speed;
+      let n = Math.min(carry | 0, 3000);
+      carry -= n;
+      while (n--) step();
+      drawBoard();
+      drawStats();
+      if (episodes !== drawnEpisodes) { drawCurve(); drawnEpisodes = episodes; }
+      requestAnimationFrame(frame);
+    }
+
+    function setRunning(on) {
+      running = on;
+      startBtn.textContent = on ? "⏸ Pause" : "▶ Start training";
+      if (on) { lastTs = performance.now(); carry = 0; requestAnimationFrame(frame); }
+    }
+    function setSpeed(mult) {
+      speed = mult;
+      s1.classList.toggle("sec", mult !== 1);
+      s200.classList.toggle("sec", mult !== 200);
+    }
+
+    startBtn.addEventListener("click", () => setRunning(!running));
+    s1.addEventListener("click", () => setSpeed(1));
+    s200.addEventListener("click", () => setSpeed(200));
+    $("tr-reset").addEventListener("click", () => {
+      resetTable(); resetBoard(); drawnEpisodes = -1;
+      drawBoard(); drawStats(); drawCurve();
+    });
+
+    onTheme(() => { drawBoard(); drawCurve(); });
+    resetTable();
+    resetBoard();
+    drawBoard();
+    drawStats();
+    drawCurve();
+  })();
+})();
+</script>
+
+</div>

--- a/docs/game.md
+++ b/docs/game.md
@@ -6,14 +6,39 @@ permalink: /game/
 
 <div class="game-container">
   <h1>Snake Game</h1>
-  <p class="game-description">Take a break and play a classic game of Snake! On desktop use the arrow keys; on a phone, swipe on the board or use the on-screen pad below. Eat the food to grow longer.</p>
-  
+  <p class="game-description">Take a break and play a classic game of Snake! On desktop use the arrow keys; on a phone, swipe on the board or use the on-screen pad below. Eat the food to grow longer. Or switch to AI mode and watch a tiny Q-learning agent teach itself to play, learning live in your browser.</p>
+
+  <div class="mode-switch" role="group" aria-label="Game mode">
+    <button class="mode-btn active" data-mode="human" id="modeHumanButton">Play yourself</button>
+    <button class="mode-btn" data-mode="ai" id="modeAIButton">Watch the AI learn</button>
+  </div>
+
   <div class="game-wrapper">
     <canvas id="gameCanvas" width="400" height="400"></canvas>
     <div class="game-controls">
       <div class="score">Score: <span id="score">0</span></div>
       <button id="startButton">Start Game</button>
       <button id="resetButton">Reset Game</button>
+    </div>
+
+    <div class="ai-panel" id="aiPanel" hidden>
+      <div class="ai-speed" role="group" aria-label="Training speed">
+        <span class="ai-speed-label">Speed:</span>
+        <button class="speed-btn active" data-speed="1">1&times;</button>
+        <button class="speed-btn" data-speed="50">50&times;</button>
+        <button class="speed-btn" data-speed="500">500&times;</button>
+      </div>
+      <div class="ai-stats">
+        <div class="ai-stat"><span class="ai-stat-value" id="statEpisodes">0</span><span class="ai-stat-label">Episodes</span></div>
+        <div class="ai-stat"><span class="ai-stat-value" id="statLast">&ndash;</span><span class="ai-stat-label">Last</span></div>
+        <div class="ai-stat"><span class="ai-stat-value" id="statBest">0</span><span class="ai-stat-label">Best</span></div>
+        <div class="ai-stat"><span class="ai-stat-value" id="statAvg">&ndash;</span><span class="ai-stat-label">Avg (50)</span></div>
+        <div class="ai-stat"><span class="ai-stat-value" id="statEpsilon">1.00</span><span class="ai-stat-label">&epsilon; (explore)</span></div>
+      </div>
+      <div class="ai-spark" id="aiSpark">
+        <canvas id="sparklineCanvas" width="400" height="90" aria-label="Score per episode"></canvas>
+      </div>
+      <button id="resetBrainButton">Reset Brain</button>
     </div>
 
     <div class="dpad" id="dpad" aria-label="Directional controls">
@@ -41,6 +66,13 @@ let gameInterval;
 let score = 0;
 let gameStarted = false;
 let listenersBound = false;
+
+// Mode: 'human' (arrow keys / swipe / d-pad) or 'ai' (Q-learning agent)
+let mode = 'human';
+
+// Board colors are CSS custom properties so the canvas matches the site theme;
+// they're cached here and refreshed when the theme toggles (see MutationObserver)
+let boardColors = null;
 
 // Initialize game
 function initGame() {
@@ -93,9 +125,43 @@ function initGame() {
       resetButton.addEventListener('click', resetGame);
     }
 
+    // Mode switch (human vs AI)
+    document.querySelectorAll('.mode-btn').forEach(btn => {
+      btn.addEventListener('click', () => setMode(btn.getAttribute('data-mode')));
+    });
+
+    // AI training speed
+    document.querySelectorAll('.speed-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        aiSpeed = parseInt(btn.getAttribute('data-speed'), 10);
+        document.querySelectorAll('.speed-btn').forEach(b => b.classList.toggle('active', b === btn));
+      });
+    });
+
+    const resetBrainButton = document.getElementById('resetBrainButton');
+    if (resetBrainButton) {
+      resetBrainButton.addEventListener('click', resetBrain);
+    }
+
+    // Canvas colors come from CSS custom properties; recolor when the site
+    // theme toggles (the toggle flips .dark-theme on <body>)
+    new MutationObserver(() => {
+      refreshBoardColors();
+      draw();
+      drawSparkline();
+    }).observe(document.body, {attributes: true, attributeFilter: ['class']});
+
+    // Don't lose the learned Q-table when the visitor leaves mid-training
+    window.addEventListener('beforeunload', () => { if (brainDirty) saveBrain(); });
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden' && brainDirty) saveBrain();
+    });
+
     listenersBound = true;
   }
   
+  refreshBoardColors();
+
   // Draw initial state
   draw();
 }
@@ -121,6 +187,7 @@ const OPPOSITE = {up: 'down', down: 'up', left: 'right', right: 'left'};
 
 // Apply a direction change from any input source (keyboard, swipe, d-pad)
 function setDirection(dir) {
+  if (mode !== 'human') return;
   if (!gameStarted) return;
   if (OPPOSITE[dir] !== direction) {
     nextDirection = dir;
@@ -221,10 +288,7 @@ function moveSnake() {
   // Check if snake ate food
   if (head.x === food.x && head.y === food.y) {
     score += 10;
-    const scoreElement = document.getElementById('score');
-    if (scoreElement) {
-      scoreElement.textContent = score;
-    }
+    updateScoreDisplay();
     generateFood();
   } else {
     snake.pop();
@@ -243,18 +307,37 @@ function checkCollision(head) {
   return snake.some(segment => segment.x === head.x && segment.y === head.y);
 }
 
+function updateScoreDisplay() {
+  const scoreElement = document.getElementById('score');
+  if (scoreElement) {
+    scoreElement.textContent = score;
+  }
+}
+
+function refreshBoardColors() {
+  if (!canvas) return;
+  const cs = getComputedStyle(canvas);
+  boardColors = {
+    bg: cs.getPropertyValue('--board-bg').trim() || '#f0f0f0',
+    snake: cs.getPropertyValue('--board-snake').trim() || '#4CAF50',
+    head: cs.getPropertyValue('--board-snake-head').trim() || '#388E3C',
+    food: cs.getPropertyValue('--board-food').trim() || '#FF5722'
+  };
+}
+
 // Draw game state
 function draw() {
   if (!ctx || !canvas) return;
+  if (!boardColors) refreshBoardColors();
   
   // Clear canvas
-  ctx.fillStyle = '#f0f0f0';
+  ctx.fillStyle = boardColors.bg;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   
   // Draw snake
   snake.forEach((segment, index) => {
-    // Make head slightly darker
-    ctx.fillStyle = index === 0 ? '#388E3C' : '#4CAF50';
+    // The head gets its own shade
+    ctx.fillStyle = index === 0 ? boardColors.head : boardColors.snake;
     ctx.fillRect(
       segment.x * GRID_SIZE,
       segment.y * GRID_SIZE,
@@ -264,7 +347,7 @@ function draw() {
   });
   
   // Draw food
-  ctx.fillStyle = '#FF5722';
+  ctx.fillStyle = boardColors.food;
   ctx.fillRect(
     food.x * GRID_SIZE,
     food.y * GRID_SIZE,
@@ -279,8 +362,13 @@ function gameLoop() {
   draw();
 }
 
-// Start game
+// Start game (in AI mode this button starts/pauses training instead)
 function startGame() {
+  if (mode === 'ai') {
+    toggleTraining();
+    return;
+  }
+
   const startButton = document.getElementById('startButton');
   if (!startButton) return;
   
@@ -295,21 +383,17 @@ function startGame() {
   }
 }
 
-// Reset game
+// Reset game (board only — the AI's learned Q-table survives; use Reset Brain for that)
 function resetGame() {
   clearInterval(gameInterval);
+  stopTraining();
   gameStarted = false;
   score = 0;
+  updateScoreDisplay();
   
-  const scoreElement = document.getElementById('score');
   const startButton = document.getElementById('startButton');
-  
-  if (scoreElement) {
-    scoreElement.textContent = score;
-  }
-  
   if (startButton) {
-    startButton.textContent = 'Start Game';
+    startButton.textContent = mode === 'ai' ? 'Start Training' : 'Start Game';
   }
   
   direction = 'right';
@@ -317,7 +401,7 @@ function resetGame() {
   initGame();
 }
 
-// Game over
+// Game over (human mode only; AI episodes end silently in endEpisode)
 function gameOver() {
   clearInterval(gameInterval);
   gameStarted = false;
@@ -330,6 +414,385 @@ function gameOver() {
   alert(`Game Over! Your score: ${score}`);
 }
 
+// ---------------------------------------------------------------------------
+// AI mode — tabular Q-learning
+//
+// State (a few hundred entries at most): danger straight/left/right relative
+// to the current heading, the heading itself, and the sign of the food's
+// offset from the head. Actions are relative (straight / turn left / turn
+// right), so the agent can never reverse into its own neck.
+// ---------------------------------------------------------------------------
+const BRAIN_KEY = 'snake-ai-brain-v1';
+const STARVE_LIMIT = 200;      // steps without food before the episode is cut off
+const HISTORY_MAX = 200;       // episodes kept for the sparkline
+const AVG_WINDOW = 50;         // rolling-average window for the stats readout
+
+const AI = {
+  alpha: 0.15,                 // learning rate
+  gamma: 0.9,                  // discount factor
+  epsilon: 1.0,                // exploration rate (decays per episode)
+  epsilonMin: 0.01,
+  epsilonDecay: 0.995,
+  q: {},                       // stateKey -> [Q(straight), Q(left), Q(right)]
+  episodes: 0,
+  best: 0,
+  history: []                  // score per episode, most recent last
+};
+
+let aiRunning = false;
+let aiSpeed = 1;               // multiplier over the human game speed
+let aiRaf = null;
+let aiLastTs = null;
+let aiStepCarry = 0;
+let stepsSinceFood = 0;
+let brainDirty = false;
+let sparkEpisodes = -1;        // episode count at last sparkline redraw
+
+// Headings in clockwise order, so "turn" is an index shift
+const DIRS = ['up', 'right', 'down', 'left'];
+
+function turnDir(dir, action) {
+  const i = DIRS.indexOf(dir);
+  if (action === 1) return DIRS[(i + 3) % 4];  // left
+  if (action === 2) return DIRS[(i + 1) % 4];  // right
+  return dir;                                  // straight
+}
+
+function nextCell(pos, dir) {
+  return {
+    x: pos.x + (dir === 'right') - (dir === 'left'),
+    y: pos.y + (dir === 'down') - (dir === 'up')
+  };
+}
+
+function getStateKey() {
+  const head = snake[0];
+  const dS = checkCollision(nextCell(head, direction)) ? 1 : 0;
+  const dL = checkCollision(nextCell(head, turnDir(direction, 1))) ? 1 : 0;
+  const dR = checkCollision(nextCell(head, turnDir(direction, 2))) ? 1 : 0;
+  const fx = Math.sign(food.x - head.x);
+  const fy = Math.sign(food.y - head.y);
+  return dS + '' + dL + dR + '|' + direction + '|' + fx + ',' + fy;
+}
+
+function getQ(stateKey) {
+  if (!AI.q[stateKey]) AI.q[stateKey] = [0, 0, 0];
+  return AI.q[stateKey];
+}
+
+function chooseAction(stateKey) {
+  if (Math.random() < AI.epsilon) {
+    return Math.floor(Math.random() * 3);
+  }
+  const q = getQ(stateKey);
+  let best = [0];
+  for (let a = 1; a < 3; a++) {
+    if (q[a] > q[best[0]]) best = [a];
+    else if (q[a] === q[best[0]]) best.push(a);
+  }
+  return best[Math.floor(Math.random() * best.length)];
+}
+
+// One environment step + one Q-update
+function aiStep() {
+  const stateKey = getStateKey();
+  const action = chooseAction(stateKey);
+  direction = turnDir(direction, action);
+  nextDirection = direction;
+
+  const head = snake[0];
+  const newHead = nextCell(head, direction);
+  const distBefore = Math.abs(food.x - head.x) + Math.abs(food.y - head.y);
+
+  let reward;
+  let done = false;
+
+  if (checkCollision(newHead)) {
+    reward = -10;
+    done = true;
+  } else {
+    snake.unshift(newHead);
+    if (newHead.x === food.x && newHead.y === food.y) {
+      score += 10;
+      stepsSinceFood = 0;
+      generateFood();
+      reward = 10;
+    } else {
+      snake.pop();
+      // Shaping: nudge toward the food; slightly asymmetric so circling
+      // in place is a net loss
+      const distAfter = Math.abs(food.x - newHead.x) + Math.abs(food.y - newHead.y);
+      reward = distAfter < distBefore ? 0.3 : -0.45;
+      stepsSinceFood++;
+      if (stepsSinceFood > STARVE_LIMIT) {
+        reward = -10;
+        done = true;
+      }
+    }
+  }
+
+  const q = getQ(stateKey);
+  const target = done ? reward : reward + AI.gamma * Math.max(...getQ(getStateKey()));
+  q[action] += AI.alpha * (target - q[action]);
+  brainDirty = true;
+
+  if (done) endEpisode();
+}
+
+function endEpisode() {
+  AI.episodes++;
+  AI.history.push(score);
+  if (AI.history.length > HISTORY_MAX) AI.history.shift();
+  if (score > AI.best) AI.best = score;
+  AI.epsilon = Math.max(AI.epsilonMin, AI.epsilon * AI.epsilonDecay);
+  if (AI.episodes % 20 === 0) saveBrain();
+  resetBoard();
+}
+
+function resetBoard() {
+  score = 0;
+  direction = 'right';
+  nextDirection = 'right';
+  snake = [
+    {x: 5, y: 5},
+    {x: 4, y: 5},
+    {x: 3, y: 5}
+  ];
+  generateFood();
+  stepsSinceFood = 0;
+}
+
+// rAF-driven training loop: 1x matches the human tick; fast-forward runs many
+// steps per frame but still renders only once per frame
+function aiFrame(ts) {
+  if (!aiRunning) return;
+  if (aiLastTs === null) aiLastTs = ts;
+  const dt = Math.min(ts - aiLastTs, 250);
+  aiLastTs = ts;
+
+  aiStepCarry += dt * aiSpeed * (1000 / GAME_SPEED) / 1000;
+  let steps = Math.floor(aiStepCarry);
+  aiStepCarry -= steps;
+  if (steps > 5000) steps = 5000;
+
+  for (let i = 0; i < steps; i++) aiStep();
+
+  draw();
+  updateScoreDisplay();
+  updateStatsDisplay();
+  if (AI.episodes !== sparkEpisodes) {
+    sparkEpisodes = AI.episodes;
+    drawSparkline();
+  }
+  aiRaf = requestAnimationFrame(aiFrame);
+}
+
+function toggleTraining() {
+  const startButton = document.getElementById('startButton');
+  if (!aiRunning) {
+    aiRunning = true;
+    aiLastTs = null;
+    aiStepCarry = 0;
+    if (startButton) startButton.textContent = 'Pause Training';
+    aiRaf = requestAnimationFrame(aiFrame);
+  } else {
+    stopTraining();
+    if (startButton) startButton.textContent = 'Resume Training';
+  }
+}
+
+function stopTraining() {
+  if (!aiRunning) return;
+  aiRunning = false;
+  if (aiRaf !== null) cancelAnimationFrame(aiRaf);
+  aiRaf = null;
+  saveBrain();
+}
+
+function setMode(newMode) {
+  if (newMode === mode) return;
+  clearInterval(gameInterval);
+  stopTraining();
+  gameStarted = false;
+  mode = newMode;
+
+  document.querySelectorAll('.mode-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.getAttribute('data-mode') === mode);
+  });
+
+  const container = document.querySelector('.game-container');
+  if (container) container.classList.toggle('ai-mode', mode === 'ai');
+
+  const aiPanel = document.getElementById('aiPanel');
+  if (aiPanel) aiPanel.hidden = mode !== 'ai';
+
+  const startButton = document.getElementById('startButton');
+  if (startButton) startButton.textContent = mode === 'ai' ? 'Start Training' : 'Start Game';
+
+  resetBoard();
+  updateScoreDisplay();
+  draw();
+  if (mode === 'ai') {
+    updateStatsDisplay();
+    drawSparkline();
+  }
+}
+
+// ---- Stats readout + sparkline ----
+
+function updateStatsDisplay() {
+  const set = (id, value) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+  };
+  const recent = AI.history.slice(-AVG_WINDOW);
+  const avg = recent.length
+    ? (recent.reduce((a, b) => a + b, 0) / recent.length).toFixed(1)
+    : '–';
+  set('statEpisodes', AI.episodes);
+  set('statLast', AI.history.length ? AI.history[AI.history.length - 1] : '–');
+  set('statBest', AI.best);
+  set('statAvg', avg);
+  set('statEpsilon', AI.epsilon.toFixed(2));
+}
+
+// Score-per-episode sparkline; colors come from --spark-* custom properties so
+// it follows the site theme
+function drawSparkline() {
+  const spark = document.getElementById('sparklineCanvas');
+  if (!spark) return;
+  const g = spark.getContext('2d');
+  if (!g) return;
+
+  const cs = getComputedStyle(spark);
+  const colors = {
+    bg: cs.getPropertyValue('--spark-bg').trim() || '#ffffff',
+    grid: cs.getPropertyValue('--spark-grid').trim() || '#eeeeee',
+    raw: cs.getPropertyValue('--spark-raw').trim() || 'rgba(34, 88, 165, 0.35)',
+    avg: cs.getPropertyValue('--spark-avg').trim() || '#2258a5',
+    text: cs.getPropertyValue('--spark-text').trim() || '#666666'
+  };
+
+  const w = spark.width;
+  const h = spark.height;
+  const pad = 6;
+
+  g.clearRect(0, 0, w, h);
+  g.fillStyle = colors.bg;
+  g.fillRect(0, 0, w, h);
+
+  const hist = AI.history;
+  if (hist.length < 2) {
+    g.fillStyle = colors.text;
+    g.font = '12px "Helvetica Neue", Helvetica, Arial, sans-serif';
+    g.textAlign = 'center';
+    g.textBaseline = 'middle';
+    g.fillText('Score per episode will chart here', w / 2, h / 2);
+    return;
+  }
+
+  const maxScore = Math.max(10, ...hist);
+  const x = i => pad + (i / (hist.length - 1)) * (w - 2 * pad);
+  const y = v => h - pad - (v / maxScore) * (h - 2 * pad);
+
+  // Faint gridline at the best score so the axis has some anchor
+  g.strokeStyle = colors.grid;
+  g.lineWidth = 1;
+  g.beginPath();
+  g.moveTo(pad, y(maxScore));
+  g.lineTo(w - pad, y(maxScore));
+  g.stroke();
+
+  // Raw per-episode scores
+  g.strokeStyle = colors.raw;
+  g.lineWidth = 1;
+  g.beginPath();
+  hist.forEach((v, i) => { i === 0 ? g.moveTo(x(i), y(v)) : g.lineTo(x(i), y(v)); });
+  g.stroke();
+
+  // Rolling average on top — this is the learning curve
+  g.strokeStyle = colors.avg;
+  g.lineWidth = 2;
+  g.beginPath();
+  let sum = 0;
+  const win = [];
+  hist.forEach((v, i) => {
+    win.push(v);
+    sum += v;
+    if (win.length > 20) sum -= win.shift();
+    const m = sum / win.length;
+    i === 0 ? g.moveTo(x(i), y(m)) : g.lineTo(x(i), y(m));
+  });
+  g.stroke();
+
+  // Best-score label
+  g.fillStyle = colors.text;
+  g.font = '10px "Helvetica Neue", Helvetica, Arial, sans-serif';
+  g.textAlign = 'left';
+  g.textBaseline = 'top';
+  g.fillText(String(maxScore), pad + 2, y(maxScore) + 2);
+}
+
+// ---- Brain persistence (localStorage) ----
+
+function saveBrain() {
+  try {
+    localStorage.setItem(BRAIN_KEY, JSON.stringify({
+      q: AI.q,
+      episodes: AI.episodes,
+      epsilon: AI.epsilon,
+      best: AI.best,
+      history: AI.history
+    }));
+    brainDirty = false;
+  } catch (e) {
+    // localStorage may be unavailable (private mode, quota) — training still works
+  }
+}
+
+function loadBrain() {
+  try {
+    const raw = localStorage.getItem(BRAIN_KEY);
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    if (data && typeof data.q === 'object' && data.q !== null) AI.q = data.q;
+    if (Number.isFinite(data.episodes)) AI.episodes = data.episodes;
+    if (Number.isFinite(data.epsilon)) {
+      AI.epsilon = Math.min(1, Math.max(AI.epsilonMin, data.epsilon));
+    }
+    if (Number.isFinite(data.best)) AI.best = data.best;
+    if (Array.isArray(data.history)) {
+      AI.history = data.history.filter(Number.isFinite).slice(-HISTORY_MAX);
+    }
+  } catch (e) {
+    // Corrupt or unreadable saved brain — start fresh
+  }
+}
+
+function resetBrain() {
+  if (!confirm('Forget everything the AI has learned?')) return;
+  const wasRunning = aiRunning;
+  stopTraining();
+  AI.q = {};
+  AI.episodes = 0;
+  AI.epsilon = 1.0;
+  AI.best = 0;
+  AI.history = [];
+  brainDirty = false;
+  try { localStorage.removeItem(BRAIN_KEY); } catch (e) {}
+  resetBoard();
+  updateScoreDisplay();
+  draw();
+  updateStatsDisplay();
+  drawSparkline();
+  if (wasRunning) toggleTraining();
+}
+
 // Initialize game when page loads
-window.addEventListener('load', initGame);
-</script> 
+window.addEventListener('load', () => {
+  loadBrain();
+  initGame();
+  updateStatsDisplay();
+  drawSparkline();
+});
+</script>

--- a/docs/style.scss
+++ b/docs/style.scss
@@ -835,6 +835,12 @@ footer {
 
 // Game styles
 .game-container {
+  // Board colors — read by the canvas JS at runtime so drawing follows the theme
+  --board-bg: #f0f0f0;
+  --board-snake: #4CAF50;
+  --board-snake-head: #388E3C;
+  --board-food: #FF5722;
+
   max-width: 800px;
   margin: 0 auto;
   padding: 2rem;
@@ -941,9 +947,211 @@ footer {
   opacity: 0.9;
 }
 
+// Mode switch (play yourself vs watch the AI learn)
+.mode-switch {
+  display: inline-flex;
+  border: 1px solid $lightBlue;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.mode-btn {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border: none;
+  background-color: $white;
+  color: $darkGray;
+  cursor: pointer;
+  transition: background-color 0.3s;
+
+  &.active {
+    background-color: $accentBlue;
+    color: $white;
+  }
+
+  &:not(.active):hover {
+    background-color: $lightBlue;
+  }
+}
+
+// Hide the touch d-pad while the AI is driving
+.game-container.ai-mode .dpad {
+  display: none;
+}
+
+// AI training panel
+.ai-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.ai-speed {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ai-speed-label {
+  font-size: 0.9rem;
+  color: $gray;
+}
+
+.speed-btn {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.9rem;
+  border: none;
+  border-radius: 4px;
+  background-color: $lightBlue;
+  color: $darkGray;
+  cursor: pointer;
+  transition: background-color 0.3s;
+
+  &.active {
+    background-color: $accentBlue;
+    color: $white;
+  }
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+.ai-stats {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem 1.4rem;
+}
+
+.ai-stat {
+  display: flex;
+  flex-direction: column;
+  min-width: 3.2rem;
+
+  .ai-stat-value {
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: $darkGray;
+  }
+
+  .ai-stat-label {
+    font-size: 0.75rem;
+    color: $gray;
+  }
+}
+
+.ai-spark {
+  // Sparkline colors — read by the canvas JS at runtime so it follows the theme
+  --spark-bg: #{$white};
+  --spark-grid: #{$lightGray};
+  --spark-raw: #{rgba($accentBlue, 0.35)};
+  --spark-avg: #{$accentBlue};
+  --spark-text: #{$gray};
+
+  width: 100%;
+
+  canvas {
+    display: block;
+    width: 100%;
+    height: 90px;
+    border: 1px solid $lightBlue;
+    border-radius: 4px;
+  }
+}
+
+#resetBrainButton {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.9rem;
+  border: none;
+  border-radius: 4px;
+  background-color: $lightBlue;
+  color: $darkGray;
+  cursor: pointer;
+  transition: background-color 0.3s;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
 // Dark theme adjustments for game
 .dark-theme {
+  .game-container {
+    --board-bg: #22262e;
+    --board-snake: #66bb6a;
+    --board-snake-head: #a5d6a7;
+    --board-food: #ff7043;
+  }
+
   .game-description {
+    color: $dark-text;
+  }
+
+  .mode-switch {
+    border-color: $dark-border;
+  }
+
+  .mode-btn {
+    background-color: $dark-bg;
+    color: $dark-text;
+
+    &.active {
+      background-color: $dark-accent;
+      color: $dark-bg;
+    }
+
+    &:not(.active):hover {
+      background-color: $dark-border;
+    }
+  }
+
+  .ai-speed-label {
+    color: $dark-gray;
+  }
+
+  .speed-btn {
+    background-color: $dark-border;
+    color: $dark-text;
+
+    &.active {
+      background-color: $dark-accent;
+      color: $dark-bg;
+    }
+  }
+
+  .ai-stat {
+    .ai-stat-value {
+      color: $dark-text;
+    }
+
+    .ai-stat-label {
+      color: $dark-gray;
+    }
+  }
+
+  .ai-spark {
+    --spark-bg: #11131c;
+    --spark-grid: #{$dark-border};
+    --spark-raw: #{rgba($dark-accent, 0.4)};
+    --spark-avg: #{$dark-accent};
+    --spark-text: #{$dark-gray};
+
+    canvas {
+      border-color: $dark-border;
+    }
+  }
+
+  #resetBrainButton {
+    background-color: $dark-border;
     color: $dark-text;
   }
 


### PR DESCRIPTION
## What's in this PR

Two related additions, vanilla JS only, no dependencies:

### 1. AI mode for the Snake game (`docs/game.md`, `docs/style.scss`)

- **Mode switch** on `/game/`: "Play yourself" (unchanged gameplay) vs "Watch the AI learn". In AI mode, keyboard/swipe/d-pad input is ignored and a tabular Q-learning agent drives the same game loop and rendering.
- **Genuine Q-learning**: compact relative state (danger straight/left/right, heading, food-direction signs → ~288 states), relative actions (turn left / straight / turn right, so reversing is impossible), rewards +10 food / −10 death or starvation, asymmetric distance shaping (+0.3 / −0.45) so circling is a net loss, ε-greedy with per-episode decay, α = 0.15, γ = 0.9.
- **Training UX**: 1×/50×/500× speed (fast modes run many steps per frame, render once per frame), live stats (episodes, last/best score, rolling average, ε), and a sparkline of score-per-episode with a rolling-average learning curve.
- **Persistence**: Q-table saved to localStorage (every 20 episodes + on pause/tab hide/close) with a confirm-guarded "Reset Brain" button.
- **Theming**: board and sparkline read CSS custom properties at runtime and redraw via a MutationObserver on the body class. Light-mode board colors are pixel-identical to before; dark mode gets a proper dark board.

### 2. Study note: "Tabular Q-Learning, Explained by a Snake" (`docs/_posts/2026-07-20-q-learning-snake.html`)

An interactive study note teaching the algorithm behind the game's AI mode, following the `docs/_posts/CLAUDE.md` design system (`--sn-*` tokens, shared components, theme-aware JS-drawn graphics). Four demos:

- A **drivable state encoder**: steer a snake with the three relative actions and watch the exact state the agent perceives, with its sensory cells highlighted.
- A **one-step TD-update calculator** with scenario buttons and α/γ sliders.
- An **ε-decay schedule chart** with an interactive decay constant.
- A **live in-page trainer**: the full algorithm learning Snake from scratch on a 12×12 board with speed control, stats, and a learning-curve canvas.

## Verification

- Jekyll build clean (only pre-existing Sass deprecation warnings).
- Automated browser checks (Playwright + Chromium) on the built site, both themes: human mode regression (start/pause/steer) passes; AI-mode input ignoring, localStorage persistence across reload, and live theme-toggle canvas recolor all pass.
- Learning confirmed: game agent reached 1,385 episodes / best score 520 in 60 s at 500×; the note's in-page trainer went from random play to rolling average ~12 (best 30) in 25 s at 200×.
- Study note demos verified numerically (TD calculator outputs exact expected values) and the note appears on the `/study-notes/` index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VN9jJEzsRNxYQj3UqwUVw

---
_Generated by [Claude Code](https://claude.ai/code/session_015VN9jJEzsRNxYQj3UqwUVw)_