### PR TITLE
Give the mobile nav search its own row and rhythm

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -37,7 +37,7 @@
               </a>
             {% endfor %}
             <button class="nav-search" aria-label="Search the site (Ctrl+K or ⌘K)">
-              <i class="fas fa-search"></i><kbd>⌘K</kbd>
+              <i class="fas fa-search"></i><span class="nav-search-label">Search</span><kbd>⌘K</kbd>
             </button>
           </nav>
         </header>

--- a/docs/style.scss
+++ b/docs/style.scss
@@ -222,7 +222,14 @@ nav {
   font-size: 18px;
 
   @include mobile {
-    margin: 15px 0 0;
+    // Flex + gap keeps every row of links on the same vertical rhythm, and lets
+    // the search button claim a row of its own (see .nav-search).
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 12px 24px;
+    margin: 18px 0 0;
     font-size: 16px;
   }
 
@@ -235,7 +242,7 @@ nav {
     transition: color 0.2s ease;
 
     @include mobile {
-      margin: 0 15px;
+      margin: 0;
       color: $blue;
     }
 
@@ -1705,13 +1712,48 @@ footer {
     background: $white;
   }
 
+  // The word "Search" is only spelled out on touch layouts, where the ⌘K hint
+  // is meaningless; on desktop the icon + shortcut carry the meaning.
+  .nav-search-label {
+    display: none;
+  }
+
   &:hover {
     border-color: $accentBlue;
     color: $accentBlue;
   }
 
   @include mobile {
-    margin: 10px 0 0;
+    // Own full-width row under the links, so it stops interrupting the grid of
+    // nav items and gets a proper touch target.
+    flex: 0 0 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    max-width: 320px;
+    min-height: 44px;
+    margin: 2px auto 0;
+    padding: 0 1em;
+    border-radius: 10px;
+    background: rgba(65, 131, 196, 0.06);
+    border-color: rgba(65, 131, 196, 0.25);
+    color: $gray;
+    font-size: 15px;
+    letter-spacing: 0.3px;
+
+    i {
+      margin-right: 0;
+    }
+
+    kbd {
+      display: none;
+    }
+
+    .nav-search-label {
+      display: inline;
+    }
   }
 }
 
@@ -1727,6 +1769,11 @@ footer {
   &:hover {
     border-color: $dark-accent;
     color: $dark-accent;
+  }
+
+  @include mobile {
+    background: rgba(100, 181, 246, 0.08);
+    border-color: rgba(100, 181, 246, 0.28);
   }
 }
 


### PR DESCRIPTION
On phones the search button sat inline with the last row of nav links,
breaking the grid and sitting at a different vertical offset than its
neighbours. Lay the mobile nav out with flex + a shared gap so every row
of links shares one rhythm, and let the search claim a full-width row of
its own underneath: a 44px-tall pill with a spelled-out "Search" label
and a tinted fill. The ⌘K hint is hidden on touch layouts, where no such
shortcut exists; desktop keeps the icon + ⌘K badge unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PWT1BQDTrWwzqo8DQPc6hA